### PR TITLE
Keep whitespace in Authors@R field

### DIFF
--- a/R/description.R
+++ b/R/description.R
@@ -27,12 +27,14 @@ cat.description <- function(field, value, file='') {
     if (field %in% c("Collate")) {
       # Individual lines
       width <- 0L
+      out <- wrap_field_if_necessary(field, value, wrap.threshold = width)
     } else if (field %in% c("Authors@R")) {
-      # No wrapping
-      width <- Inf
+      # No processing
+      out <- paste0(field, ": ", value)
+    } else {
+      out <- wrap_field_if_necessary(field, value, wrap.threshold = width)
     }
 
-    out <- wrap_field_if_necessary(field, value, wrap.threshold = width)
   }
 
   cat(out, sep='\n', file=file, append=TRUE)

--- a/R/description.R
+++ b/R/description.R
@@ -1,6 +1,6 @@
 # Parse DESCRIPTION into convenient format
 read.description <- function(file) {
-  dcf <- read.dcf(file)
+  dcf <- read.dcf(file, keep.white = "Authors@R")
 
   dcf_list <- setNames(as.list(dcf[1, ]), colnames(dcf))
   lapply(dcf_list, str_trim)

--- a/tests/testthat/description-example_2.txt
+++ b/tests/testthat/description-example_2.txt
@@ -1,0 +1,23 @@
+Package: foobar
+Version: 2.0
+License: GPL (>= 2)
+Description: The second version of this nonexistent package only differs in that the maintainer decided to edit the fake author information, using some features of the Authors@R field to see if formatting will be preserved, and removing some inexistent authors that did really not contribute anything to the nonsense. Otherwise, the package described herein is still fake, entirely manufactured, utterly contrived, and wholly nonexistent. In no way does it reflect the work, endorsement, or even approval of the creators named, nor is it meant to. It contains no functions, which even if they did exist would take no arguments, and even if such hypothetical functions did exist and took arguments still wouldn't return anything.
+Title: A fake package for testing purposes
+Authors@R: c(
+    person("Alan Turing", role = c("auth", "cre", "cph"),
+           email = "alan@turing.fake",
+           comment = c("As this is a fake package, as you may have guessed, authorship"
+                       "information should not be taken seriously either."),
+    person("Alonzo Church", role = "ctb",
+            email = "alonzo@church.fake"),
+    person("Grace Murray Hopper", role = "auth",
+            email = "grace@murray-hopper.fake"))
+Imports:
+    stringr (>= 0.5),
+    tools,
+    brew
+Suggests:
+    testthat
+Depends:
+    digest
+Collate: 'cache.R' 'description.R' 'parse.R' 'parse-preref.R' 'parse-srcref.R' 'parse-registry.R' 'rd-file-api.R' 'rd-tag-api.R' 'roclet-collate.R' 'roclet-namespace.R' 'roclet-rd.R' 'roclet.R' 'roxygen.R' 'roxygenize.R' 'topo-sort.R' 'utils.R' 'template.R' 'rd-parse.R'

--- a/tests/testthat/test-wrapFieldIfNecessary.R
+++ b/tests/testthat/test-wrapFieldIfNecessary.R
@@ -56,10 +56,26 @@ test_that("DESCRIPTION fields DO NOT get wrapped if no line exceeds the wrapping
 )
 
 test_that("Infinity threshold turns off wrapping", {
-  poem <- paste(sample(letters, 1000, TRUE), collapse = "")
-  expect_equal(
-    wrap_field_if_necessary("LongPoem", poem, wrap.threshold = Inf),
-    paste("LongPoem:", poem)
-  )
-}
+    poem <- paste(sample(letters, 1000, TRUE), collapse = "")
+    expect_equal(
+      wrap_field_if_necessary("LongPoem", poem, wrap.threshold = Inf),
+      paste("LongPoem:", poem)
+    )
+  }
+)
+
+test_that("Whitespace in Authors@R field of DESCRIPTION is preserved", {
+    desc_2 <- read.description("description-example_2.txt")
+    authors_at_R_raw <- "Authors@R: c(
+    person('Alan Turing', role = c('auth', 'cre', 'cph'),
+           email = 'alan@turing.fake',
+           comment = c('As this is a fake package, as you may have guessed, authorship'
+                       'information should not be taken seriously either.'),
+    person('Alonzo Church', role = 'ctb',
+            email = 'alonzo@church.fake'),
+    person('Grace Murray Hopper', role = 'auth',
+            email = 'grace@murray-hopper.fake'))"
+    authors_at_R_formatted <- capture.output(cat.description("Authors@R", desc_2[["Authors@R"]], file = ''))
+    expect_equal(paste(authors_at_R_formatted, collapse = "\n"), authors_at_R_formatted)
+  }
 )

--- a/tests/testthat/test-wrapFieldIfNecessary.R
+++ b/tests/testthat/test-wrapFieldIfNecessary.R
@@ -67,15 +67,15 @@ test_that("Infinity threshold turns off wrapping", {
 test_that("Whitespace in Authors@R field of DESCRIPTION is preserved", {
     desc_2 <- read.description("description-example_2.txt")
     authors_at_R_raw <- "Authors@R: c(
-    person('Alan Turing', role = c('auth', 'cre', 'cph'),
-           email = 'alan@turing.fake',
-           comment = c('As this is a fake package, as you may have guessed, authorship'
-                       'information should not be taken seriously either.'),
-    person('Alonzo Church', role = 'ctb',
-            email = 'alonzo@church.fake'),
-    person('Grace Murray Hopper', role = 'auth',
-            email = 'grace@murray-hopper.fake'))"
+    person(\"Alan Turing\", role = c(\"auth\", \"cre\", \"cph\"),
+           email = \"alan@turing.fake\",
+           comment = c(\"As this is a fake package, as you may have guessed, authorship\"
+                       \"information should not be taken seriously either.\"),
+    person(\"Alonzo Church\", role = \"ctb\",
+            email = \"alonzo@church.fake\"),
+    person(\"Grace Murray Hopper\", role = \"auth\",
+            email = \"grace@murray-hopper.fake\"))"
     authors_at_R_formatted <- capture.output(cat.description("Authors@R", desc_2[["Authors@R"]], file = ''))
-    expect_equal(paste(authors_at_R_formatted, collapse = "\n"), authors_at_R_formatted)
+    expect_equal(authors_at_R_raw, paste(authors_at_R_formatted, collapse = "\n"))
   }
 )


### PR DESCRIPTION
As the structure of the Authors@R field is potentially a bit more
complex than that of the other fields, this commmit leads to whitespace
being preserved when reading in the Authors@R field.