### PR TITLE
Allow missing space before @include

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
   for fields parsed from the "introduction" (the text before the first tag)
   (@gaborcsardi, #370)
 
+* Space before `@include` is not necessary anymore (@krlmlr, #342).
+
 # roxygen2 4.1.1
 
 * Formatting of the `Authors@R` field in the DESCRIPTION file is now retained 

--- a/R/roclet-collate.R
+++ b/R/roclet-collate.R
@@ -72,7 +72,7 @@ generate_collate <- function(base_path) {
 
 find_includes <- function(path) {
   lines <- readLines(path, warn = FALSE)
-  re <- regexec("^\\s*#+' @include (.*)$", lines)
+  re <- regexec("^\\s*#+' ?@include (.*)$", lines)
   matches <- regmatches(lines, re)
   matches <- Filter(function(x) length(x) == 2, matches)
 

--- a/tests/testthat/collate/belt.R
+++ b/tests/testthat/collate/belt.R
@@ -1,3 +1,4 @@
-#' @include pants.R 
-#' @include shirt.R
+# The space before @ is missing on purpose (#342).
+#'@include pants.R
+#'@include shirt.R
 NULL


### PR DESCRIPTION
This is inconsistent, other tags allow a space before @, but @include doesn't.

Includes a test.

There is code duplication, the detection of a roxygen comment is also encoded in `LINE.DELIMITER` ([code ref](https://github.com/klutometis/roxygen/blob/cbd488066b7def0de00d679a076fbcaca94b74a0/R/parse-preref.R#L28)) but there the caret (start of text indicator) is missing. What to do about that?