### PR TITLE
Revert "Don't write blank namespace. Closes #276"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
   for fields parsed from the "introduction" (the text before the first tag)
   (@gaborcsardi, #370)
 
+* Empty `NAMESPACE` file is written if it is maintained by `roxygen2`
+  (@krlmlr, #348).
+
 # roxygen2 4.1.1
 
 * Formatting of the `Authors@R` field in the DESCRIPTION file is now retained 

--- a/R/roclet-namespace.R
+++ b/R/roclet-namespace.R
@@ -62,8 +62,6 @@ ns_process_tag <- function(tag_name, partitum) {
 #' @export
 roc_output.namespace <- function(roclet, results, base_path, options = list(),
                                  check = TRUE) {
-  if (length(results) == 0) return()
-
   NAMESPACE <- file.path(base_path, "NAMESPACE")
   results <- c(made_by("#"), results)
 


### PR DESCRIPTION
This reverts commit cc6b8aa2964cd78e9ffc43af06bd050eb3623169.

The shortcut is no more necessary, as roxygen2 won't overwrite files that do not include the "magic comment". On the other hand, the shortcut prevents creation of truly empty `NAMESPACE` files.