### PR TITLE
ignore first line when comparing file contents

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -116,6 +116,10 @@ same_contents <- function(path, contents) {
 
   contents <- paste0(paste0(contents, collapse = "\n"), "\n")
 
+  # Replace contents of first line by original file
+  first_line_file <- readLines(path, 1L)
+  contents <- gsub("^[^\n]*(\n.*$)", sprintf("%s\\1", first_line_file), contents)
+
   text_hash <- digest::digest(contents, serialize = FALSE)
   file_hash <- digest::digest(file = path)
 


### PR DESCRIPTION
Following @leeper's suggestion in #334.

True, this alone will lead to different versions in the headers over time. But this is really much simpler than maintaining the version information in a dedicated file (where? `DESCRIPTION`? a new file? `NAMESPACE` is not necessarily created by us...), and if a generated file is updated, the version info will be updated too.