### PR TITLE
@family refers to name only, not all aliases, #283

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 4.1.1.9000
 
+* `@family` now cross-links each manual page only once, instread of linking
+  to all aliases (#283, #367)
+
 * Roxygen now records its version in a single place: the `RoxygenNote`
   field in the `DESCRIPTION` (#338).
 

--- a/R/family.R
+++ b/R/family.R
@@ -10,12 +10,11 @@ process_family <- function(topics) {
       others <- setdiff(related, topic_name)
       
       if (length(others) < 1) next;
-      
-      
+
       by_file <- vapply(alias_lookup[others], function(x) {
-        paste0("\\code{\\link{", sort_c(escape(x)), "}}", collapse = ", ")
+        paste0("\\code{\\link{", escape(x[1]), "}}")
       }, FUN.VALUE = character(1))
-      links <- paste(sort_c(by_file), collapse ="; ")
+      links <- paste(sort_c(by_file), collapse =", ")
       
       seealso <- paste("Other ", family, ": ", sep = "")
       out <- strwrap(links, initial = seealso, width = 60, exdent = 2)

--- a/tests/testthat/test-family.R
+++ b/tests/testthat/test-family.R
@@ -38,3 +38,21 @@ test_that("special names escaped in family tag", {
   expect_match(seealso, "\\\\%\\+\\\\%")
   
 })
+
+test_that("family links to name only, not all aliases", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Title
+    #' @aliases f2 f3
+    #' @family many aliases
+    f <- function() {}
+
+    #' Title
+    #' @aliases g2 g3
+    #' @family many aliases
+    g <- function() {}
+  ")[[1]]
+
+  seealso <- get_tag(out, "seealso")$values
+  expect_equal(str_count(seealso, fixed("\\code{\\link")), 1)
+
+})


### PR DESCRIPTION
I had this PR lying around. Details were discussed at #283. 

I am actually not convinced that this is always the good behavior. Sometimes it makes sense to link to all aliases, so if you have an idea on how to make this user configurable, per family, probably, I can update this PR.