### PR TITLE
Parse R files in collation order

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -1,6 +1,6 @@
 parse_package <- function(base_path, load_code) {
   env <- load_code(base_path)
-  parsed <- lapply(r_files(base_path), parse_file, env = env)
+  parsed <- lapply(package_files(base_path), parse_file, env = env)
   blocks <- unlist(parsed, recursive = FALSE)
 
   list(env = env, blocks = blocks)

--- a/R/source.R
+++ b/R/source.R
@@ -57,6 +57,7 @@ package_files <- function(path) {
   all <- r_files(path)
   collate <- scan(text = desc$Collate %||% "", what = "", sep = " ",
     quiet = TRUE)
+  collate <- file.path(path, "R", collate)
 
   c(collate, setdiff(all, collate))
 }


### PR DESCRIPTION
so that the order of documentation that comes from multiple files can be controlled

Looks like package_files() and probably also source_package() was broken before, because r_paths() returns absolute paths. Need to investigate.

@hadley: Do you like the idea?