### PR TITLE
Fixed conflict with raster package

### DIFF
--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -86,7 +86,7 @@ roc_process.had <- function(roclet, parsed, base_path, options = list()) {
 
 invert <- function(x) {
   if (length(x) == 0) return()
-  unstack(rev(stack(x)))
+  utils::unstack(rev(utils::stack(x)))
 }
 get_values <- function(topics, tag) {
   tags <- lapply(topics, get_tag, tag)


### PR DESCRIPTION
There is a conflict with the `raster` package which means that when a user has `raster` installed and tries to roxygenise a package that makes use of the `@family' tag it will fail:

```
Updating zoon documentation
Loading zoon
Error in .local(.Object, ...) : 
  `W:\PYWELL_SHARED\Pywell Projects\BRC\Tom August\ZOON\zoon_package\testname' does not exist in the file system,
and is not recognised as a supported dataset name.


Error in unstack(rev(stack(x))) : 
  error in evaluating the argument 'x' in selecting a method for function 'unstack': Error in .rasterObjectFromFile(x, band = band, objecttype = "RasterLayer",  : 
  Cannot create a RasterLayer object from this file. (file does not exist)
Calls: rev ... raster -> raster -> .local -> .rasterObjectFromFile
Calls: suppressPackageStartupMessages ... roc_process.had -> process_family -> invert -> unstack
Execution halted

Exited with status 1.
```

This is because in `roxygen` the function `invert` uses the functions `unstack` and `stack` which are exported by raster.

I have fixed this by changing

```R
invert <- function(x) {
   if (length(x) == 0) return()
   unstack(rev(stack(x)))
}
```

to 

```R
invert <- function(x) {
   if (length(x) == 0) return()
   utils::unstack(rev(utils::stack(x)))
}
```