### PR TITLE
Fix, whitespace was detected as intro @details

### DIFF
--- a/R/parse-preref.R
+++ b/R/parse-preref.R
@@ -24,6 +24,7 @@ parse_description <- function(tags) {
   }
 
   intro <- tags[[1]]
+  intro$val <- str_trim(intro$val)
   tags <- tags[-1]
   tag_names <- tag_names[-1]
 

--- a/tests/testthat/test-introduction.R
+++ b/tests/testthat/test-introduction.R
@@ -88,3 +88,21 @@ test_that("details are merged if needed", {
   expect_equal(get_tag(out, "details")$values,
                "Details1\n\nDetails2\n\nDetails3\n\nDetails4")
 })
+
+test_that("whitespace is not detected as details", {
+  expect_silent(
+    out <- roc_proc_text(
+      rd_roclet(), "
+        #' Title
+        #'
+        #'
+        #' Description
+        #'
+        #'
+        #'
+        foo <- function(x) {}"
+    )[[1]]
+  )
+
+  expect_null(get_tag(out, "details"))
+})


### PR DESCRIPTION
This was added in be2d3ea70075f52de3c6b33471c00161d54c7b87

I forgot a str_trim() and never found it in the tests, because my test docs were tidy. Please merge this before the release.