### PR TITLE
Allow empty line after @template

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -23,7 +23,7 @@ process_templates <- function(partitum, base_path) {
   template_tags <- partitum[template_locs]
   if (length(template_tags) == 0) return(partitum)
 
-  templates <- trimws(unlist(template_tags, use.names = FALSE))
+  templates <- str_trim(unlist(template_tags, use.names = FALSE))
   paths <- vapply(templates, template_find, base_path = base_path,
     FUN.VALUE = character(1), USE.NAMES = FALSE)
 

--- a/R/template.R
+++ b/R/template.R
@@ -23,7 +23,7 @@ process_templates <- function(partitum, base_path) {
   template_tags <- partitum[template_locs]
   if (length(template_tags) == 0) return(partitum)
 
-  templates <- unlist(template_tags, use.names = FALSE)
+  templates <- trimws(unlist(template_tags, use.names = FALSE))
   paths <- vapply(templates, template_find, base_path = base_path,
     FUN.VALUE = character(1), USE.NAMES = FALSE)
 

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -29,3 +29,12 @@ test_that("templates replace variables with their values", {
   expect_equal(get_tag(out, "title")$values, "a")
   expect_equal(get_tag(out, "param")$values, c(b = "c"))
 })
+
+test_that("allow empty line after @template", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' @template values
+    #'
+    x <- 10")[[1]]
+
+  expect_equal(get_tag(out, "title")$values, "a")
+})

--- a/tests/testthat/test-template.R
+++ b/tests/testthat/test-template.R
@@ -34,6 +34,9 @@ test_that("allow empty line after @template", {
   out <- roc_proc_text(rd_roclet(), "
     #' @template values
     #'
+    #' @templateVar x a
+    #' @templateVar y b
+    #' @templateVar z c
     x <- 10")[[1]]
 
   expect_equal(get_tag(out, "title")$values, "a")


### PR DESCRIPTION
Currently, the trailing `\n` is included in the template name. Is there a better alternative to `trimws()`?