### PR TITLE
Fix wrong call in tag_warning at parse.toggle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # roxygen2 5.0.0.9000
 
 * `@export` again allows trailing new line (#415).
+* Fixed bug in `@noRd`, where usage would cause error (#418).
 
 # roxygen2 5.0.0
 

--- a/R/parse-preref.R
+++ b/R/parse-preref.R
@@ -180,7 +180,7 @@ parse.name <- function(x) {
 
 parse.toggle <- function(x) {
   if (x$val != "") {
-    tag_warning("has no parameters")
+    tag_warning(x, "has no parameters")
   } else {
     x
   }

--- a/R/parse-preref.R
+++ b/R/parse-preref.R
@@ -179,6 +179,8 @@ parse.name <- function(x) {
 }
 
 parse.toggle <- function(x) {
+  x$val <- str_trim(x$val)
+  
   if (x$val != "") {
     tag_warning(x, "has no parameters")
   } else {


### PR DESCRIPTION
x should be passed as the first parameter. As discussed in #418 