### PR TITLE
use 'ls()' instead of 'names()' (closes #422)

### DIFF
--- a/R/tag-registry.R
+++ b/R/tag-registry.R
@@ -3,7 +3,7 @@ tags <- new.env(parent = emptyenv())
 parse_tag <- function(x) {
   stopifnot(is.roxygen_tag(x))
 
-  if (!(x$tag %in% names(tags))) {
+  if (!(x$tag %in% ls(tags))) {
     return(tag_warning(x, "unknown tag"))
   }
 


### PR DESCRIPTION
`names(environment)` became a synonym `ls(environment)` in R 3.2; it returned `NULL` prior to that.