### PR TITLE
Print source location in error message about missing name

### DIFF
--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -88,7 +88,7 @@ block_to_rd <- function(block, base_path, env) {
 
   # Determine name
   name <- block$name %||% default_topic_name(block$object) %||%
-    stop("Missing name", call. = FALSE)
+    stop("Missing name at ", srcref_location(block$srcref), call. = FALSE)
   add_tag(rd, new_tag("name", name))
 
   # Add backreference to source


### PR DESCRIPTION
Otherwise it might be a bit difficult to spot.