### PR TITLE
Use more robust method to find DESCRIPTION when processing _PACKAGE sentinel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,9 @@
 
 * Multiple `@examples` sections are merged (#472, @krlmlr).
 
+* The new `_PACKAGE` sentinel now also works from `roxygenise()`; before
+  it only worked from `devtools::document()` (#439, @krlmlr).
+
 # roxygen2 5.0.1
 
 * Use `ls()`, not `names()` to list elements of environment: fixes R 3.1.0

--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -1,9 +1,9 @@
-object_from_call <- function(call, env, block) {
+object_from_call <- function(call, env, block, file) {
   if (is.null(call)) return()
 
   # Special case: you can refer to other objects as strings
   if (is.character(call)) {
-    value <- find_data(call, env)
+    value <- find_data(call, env, file)
     value <- standardise_obj(call, value, env, block)
 
     return(object(value, call))
@@ -23,9 +23,9 @@ object_from_call <- function(call, env, block) {
   parser(call, env, block)
 }
 
-find_data <- function(name, env) {
+find_data <- function(name, env, file) {
   if (identical(name, "_PACKAGE")) {
-    return(find_data_for_package(env))
+    return(find_data_for_package(env, file))
   }
 
   ns <- env_namespace(env)
@@ -36,10 +36,9 @@ find_data <- function(name, env) {
   }
 }
 
-find_data_for_package <- function(env) {
-  ns <- env_namespace(env)
-  desc <- read.description(file.path(
-    getNamespaceInfo(ns, "path"), "DESCRIPTION"))
+find_data_for_package <- function(env, file) {
+  pkg_path <- dirname(dirname(file))
+  desc <- read.description(file.path(pkg_path, "DESCRIPTION"))
 
   if (!identical(desc$Package, utils::packageName(env))) {
     warning("Inconsistent package names: ",

--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -40,12 +40,6 @@ find_data_for_package <- function(env, file) {
   pkg_path <- dirname(dirname(file))
   desc <- read.description(file.path(pkg_path, "DESCRIPTION"))
 
-  if (!identical(desc$Package, utils::packageName(env))) {
-    warning("Inconsistent package names: ",
-            desc$Package, " vs. ", utils::packageName(env),
-            call. = FALSE)
-  }
-
   structure(list(desc = desc), class = "package")
 }
 

--- a/R/parse.R
+++ b/R/parse.R
@@ -31,7 +31,7 @@ parse_file <- function(file, env) {
     preref <- parse_preref(comment_ref, file)
     if (length(preref) == 0) return()
 
-    preref$object <- object_from_call(call, env, preref)
+    preref$object <- object_from_call(call, env, preref, file)
     preref$srcref <- list(filename = file, lloc = as.vector(ref))
     add_defaults(preref)
   }


### PR DESCRIPTION
so that it also works with roxygen2::roxygenise().

Fixes #439.