### PR TITLE
Fix @inheritParams for multi parameter lines

### DIFF
--- a/R/inherit-params.R
+++ b/R/inherit-params.R
@@ -71,8 +71,8 @@ find_params <- function(inheritor, topics, name_lookup) {
   param_names <- str_trim(names(params))
   param_names[param_names == "\\dots"] <- "..."
 
-  # Split up compound names on , duplicating their contents
-  individual_names <- strsplit(param_names, ",")
+  # Split up compound names on , (swallowing spaces) duplicating their contents
+  individual_names <- strsplit(param_names, ",[ ]*")
   reps <- vapply(individual_names, length, integer(1))
 
   setNames(rep.int(params, reps), unlist(individual_names))

--- a/R/inherit-params.R
+++ b/R/inherit-params.R
@@ -72,7 +72,7 @@ find_params <- function(inheritor, topics, name_lookup) {
   param_names[param_names == "\\dots"] <- "..."
 
   # Split up compound names on , (swallowing spaces) duplicating their contents
-  individual_names <- strsplit(param_names, ",[ ]*")
+  individual_names <- strsplit(param_names, ",\\s*")
   reps <- vapply(individual_names, length, integer(1))
 
   setNames(rep.int(params, reps), unlist(individual_names))

--- a/tests/testthat/test-param.R
+++ b/tests/testthat/test-param.R
@@ -58,6 +58,18 @@ test_that("multiple @inheritParam inherits from existing topics", {
   expect_equal(sort(names(params)), c("trim", "x"))
 })
 
+
+test_that("@inheritParam can cope with multivariable argument definitions", {
+  out <- roc_proc_text(rd_roclet(), "
+                       #' My merge
+                       #'
+                       #' @inheritParams base::merge
+                       mymerge <- function(x, y) {}")[[1]]
+  params <- get_tag(out, "param")$values
+  expect_equal(length(params), 2)
+  expect_equal(sort(names(params)), c("x", "y"))
+})
+
 test_that("@inheritParam understands compound docs", {
   out <- roc_proc_text(rd_roclet(), "
     #' Title


### PR DESCRIPTION
The names of params for multi param lines were not being trimmed after being split.

See 17017b0f8546c19301f1650e3fe03bf789bb72a5 for discussion of alternatives to this particular fix.