### PR TITLE
cover simplest case where UseMethod has only one argument in generic,…

### DIFF
--- a/R/s3.R
+++ b/R/s3.R
@@ -32,8 +32,7 @@ calls_use_method <- function(x) {
   # Base cases
   if (missing(x)) return(FALSE)
   if (!is.call(x)) return(FALSE)
-
-  if (identical(x[[1]], quote(UseMethod))) return(TRUE)
+  if (identical(x[[1]], quote(UseMethod)) && length(x) == 2) return(TRUE)
   if (length(x) == 1) return(FALSE)
   # Recursive case: arguments to call
   for (arg in as.list(x[-1])) {


### PR DESCRIPTION
… but doesn't in re-used UseMethod invocation in S3 methods.

fixes #448 
