### PR TITLE
Roxygen handles code in OS specific subdirectories

### DIFF
--- a/R/roclet-collate.R
+++ b/R/roclet-collate.R
@@ -53,7 +53,7 @@ update_collate <- function(base_path) {
 }
 
 generate_collate <- function(base_path) {
-  paths <- sort_c(dir(base_path, pattern = "[.][Rr]$", full.names = TRUE))
+  paths <- sort_c(r_files(base_path))
   includes <- lapply(paths, find_includes)
   names(includes) <- paths
 

--- a/R/roclet-rd.R
+++ b/R/roclet-rd.R
@@ -178,7 +178,7 @@ roc_output.rd_roclet <- function(roclet, results, base_path, options = list(),
 
 #' @export
 clean.rd_roclet <- function(roclet, base_path) {
-  rd <- dir(file.path(base_path, "man"), full.names = TRUE)
+  rd <- tools::list_files_with_type(file.path(base_path, "man"), "docs")
   rd <- rd[!file.info(rd)$isdir]
   made_by_me <- vapply(rd, made_by_roxygen, logical(1))
 

--- a/R/roclet-vignette.R
+++ b/R/roclet-vignette.R
@@ -32,11 +32,9 @@ roc_output.vignette <- function(roclet, results, base_path, options = list(),
 # any of the related files are older than the vignette.
 vign_outdated <- function(vign) {
   vign <- normalizePath(vign, mustWork = TRUE)
-  name <- tools::file_path_sans_ext(basename(vign))
 
   # Currently, the final product of a vignette can only be pdf or html
-  related <- dir(dirname(vign), pattern = paste0(name, "\\.(pdf|html)$"),
-    full.names = TRUE)
+  related <- tools::list_files_with_type(dirname(vign), "vignette")
   related <- setdiff(related, vign)
 
   length(related) == 0 || mtime(vign) > mtime(related)

--- a/R/source.R
+++ b/R/source.R
@@ -54,7 +54,7 @@ load_pkg_dependencies <- function(path) {
 package_files <- function(path) {
   desc <- read_pkg_description(path)
 
-  all <- normalizePath(r_files(path))
+  all <- normalizePath(r_files(file.path(path, "R")))
   collate <- scan(text = desc$Collate %||% "", what = "", sep = " ",
     quiet = TRUE)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -124,7 +124,7 @@ same_contents <- function(path, contents) {
 }
 
 r_files <- function(path) {
-  sort_c(dir(file.path(path, "R"), "[.Rr]$", full.names = TRUE))
+  sort_c(tools::list_files_with_type(path, "code"))
 }
 
 dots <- function(...) {


### PR DESCRIPTION
This PR basically just uses `tools::list_files_with_type` which handles files in os specific directories. This gets us at least part of the way to handling OS specific subdirectories.

Things still missing would be support for separate `Collate.unix` and `Collate.windows` directives and writing documentation to `man/unix/` and `man/windows`. These features aren't widely used and I am also unsure what the roclet syntax should look like, so I did not try to tackle that.