### PR TITLE
Global option for markdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,5 @@ Suggests:
     covr
 VignetteBuilder: knitr
 LinkingTo: Rcpp
+Roxygen: list(markdown = TRUE)
 RoxygenNote: 5.0.1.9000

--- a/NEWS.md
+++ b/NEWS.md
@@ -94,7 +94,7 @@
 
 * Most fields can now be written using Markdown markup instead of the
   traditional Rd language. See the 'markdown' vignette for details
-  (#364, #431), by @gaborcsardi
+  (#364, #431, #499, #506, #507), by @gaborcsardi
 
 # roxygen2 5.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -92,8 +92,6 @@
 
 * Exported `roxy_tag()`, `roxy_tag_warning()` and 
 
-# roxygen2 5.0.1
-
 * Most fields can now be written using Markdown markup instead of the
   traditional Rd language. See the 'markdown' vignette for details
   (#364, #431), by @gaborcsardi

--- a/NEWS.md
+++ b/NEWS.md
@@ -93,8 +93,11 @@
 * Exported `roxy_tag()`, `roxy_tag_warning()` and 
 
 * Most fields can now be written using Markdown markup instead of the
-  traditional Rd language. See the 'markdown' vignette for details
-  (#364, #431, #499, #506, #507), by @gaborcsardi
+  traditional Rd language. You can turn on Markdown globally by adding
+  `Roxygen: list(markdown = TRUE)` to `DESCRIPTION`. The `@md` / `@noMd`
+  tags turn Markdown parsing on / off for the given block. See the
+  'markdown' vignette for more details (#364, #431, #499, #506, #507),
+  by @gaborcsardi
 
 # roxygen2 5.0.1
 

--- a/R/collate.R
+++ b/R/collate.R
@@ -16,7 +16,6 @@
 #' and you can't source the files unless you know the correct order.
 #'
 #' @param base_path Path to package directory.
-#' @md
 #' @examples
 #' #' `example-a.R', `example-b.R' and `example-c.R' reside
 #' #' in the `example' directory, with dependencies

--- a/R/markdown-escaping.R
+++ b/R/markdown-escaping.R
@@ -20,7 +20,6 @@
 #' `@aliases`, `@backref`, etc. only use the
 #' standard Roxygen parser.
 #'
-#' @md
 #' @param text Input text. Potentially contains Rd and/or
 #'   markdown markup.
 #' @return For `escape_rd_for_md`:
@@ -54,7 +53,6 @@ escaped_for_md <- paste0("\\", c(
 #' @param esc_text The original escaped text from
 #'   [escape_rd_for_md()].
 #' @return For `unescape_rd_for_md`: Rd text.
-#' @md
 #' @rdname markdown-internals
 unescape_rd_for_md <- function(rd_text, esc_text) {
   id <- attr(esc_text, "roxygen-markdown-subst")$id

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -1,5 +1,10 @@
-# Hacky global switch - will be eliminated when we turn md on for
-# all
+
+## If not specified in DESCRIPTION
+markdown_global_default <- FALSE
+
+## Hacky global switch - this uses the fact that blocks are parsed
+## one after the another, and that we set markdown on/off before each
+## block
 
 markdown_env <- new.env(parent = emptyenv())
 markdown_on <- function(value = NULL) {

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -263,7 +263,6 @@ add_linkrefs_to_md <- function(text) {
 #' @param destination string constant, the "url" of the link
 #' @param contents An XML node, containing the contents of the link.
 #'
-#' @md
 #' @noRd
 #' @importFrom xml2 xml_name
 
@@ -360,7 +359,6 @@ is_empty_xml <- function(x) {
 #'
 #' In another package: [and this one][devtools::document].
 #'
-#' @md
 #' @name markdown-test
 #' @keywords internal
 NULL

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -9,7 +9,6 @@ ns_tags <- c('export', 'exportClass', 'exportMethod', 'exportPattern',
 #' (<http://cran.r-project.org/doc/manuals/R-exts.pdf>) for details.
 #'
 #' @family roclets
-#' @md
 #' @export
 #' @seealso `vignette("namespace", package = "roxygen2")`
 #' @aliases export exportClass exportMethod S3method import importFrom

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -19,7 +19,8 @@ namespace_roclet <- function() {
 }
 
 #' @export
-roclet_process.roclet_namespace <- function(x, parsed, base_path) {
+roclet_process.roclet_namespace <- function(x, parsed, base_path,
+                                            global_options = list()) {
   ns <- unlist(lapply(parsed$blocks, block_to_ns)) %||% character()
   sort_c(unique(ns))
 }

--- a/R/object-format.R
+++ b/R/object-format.R
@@ -6,7 +6,6 @@
 #'
 #' @param x A data object
 #' @return A `character` value with valid `Rd` syntax, or `NULL`.
-#' @md
 #' @export
 object_format <- function(x) {
   UseMethod("object_format")

--- a/R/object-s3.R
+++ b/R/object-s3.R
@@ -8,7 +8,6 @@
 #' `is_s3_method` builds names of all possible generics for that function
 #' and then checks if any of them actually is a generic.
 #'
-#' @md
 #' @param name Name of function.
 #' @param env Base environment in which to look for function defintion.
 #' @export

--- a/R/parse.R
+++ b/R/parse.R
@@ -1,14 +1,15 @@
-parse_package <- function(base_path, load_code, registry) {
+parse_package <- function(base_path, load_code, registry, global_options = list()) {
   env <- load_code(base_path)
 
   files <- package_files(base_path)
-  parsed <- lapply(files, parse_blocks, env = env, registry = registry)
+  parsed <- lapply(files, parse_blocks, env = env, registry = registry,
+                   global_options = global_options)
   blocks <- unlist(parsed, recursive = FALSE)
 
   list(env = env, blocks = blocks)
 }
 
-parse_text <- function(text, registry = default_tags()) {
+parse_text <- function(text, registry = default_tags(), global_options = list()) {
   file <- tempfile()
   writeLines(text, file)
   on.exit(unlink(file))
@@ -17,12 +18,13 @@ parse_text <- function(text, registry = default_tags()) {
   methods::setPackageName("roxygen_devtest", env)
 
   sys.source(file, envir = env)
-  blocks <- parse_blocks(file, env, registry = registry)
+  blocks <- parse_blocks(file, env, registry = registry,
+                         global_options = global_options)
 
   list(env = env, blocks = blocks)
 }
 
-parse_blocks <- function(file, env, registry) {
+parse_blocks <- function(file, env, registry, global_options = list()) {
   parsed <- parse(file = file, keep.source = TRUE)
   if (length(parsed) == 0) return()
 
@@ -30,7 +32,8 @@ parse_blocks <- function(file, env, registry) {
   comment_refs <- comments(refs)
 
   extract <- function(call, ref, comment_ref) {
-    block <- parse_block(comment_ref, file, registry)
+    block <- parse_block(comment_ref, file, registry,
+                         global_options = global_options)
     if (length(block) == 0) return()
 
     block$object <- object_from_call(call, env, block, file)
@@ -41,13 +44,30 @@ parse_blocks <- function(file, env, registry) {
   Map(extract, parsed, refs, comment_refs)
 }
 
-parse_block <- function(x, file, registry, offset = x[[1]]) {
+parse_block <- function(x, file, registry, offset = x[[1]], global_options = list()) {
   tags <- tokenise_block(as.character(x), file = basename(file), offset = offset)
   if (length(tags) == 0)
     return()
 
-  ## Switch markdown on/off if md absent/present
-  markdown_on("md" %in% vapply(tags, "[[", "", "tag"))
+  ## markdown on/off based on global flag and presense of @md & @nomd
+  ## we need to use markdown_global_default as well, because global_options
+  ## can be NULL, e.g. if called from parse_text()
+
+  names <- vapply(tags, `[[`, "tag", FUN.VALUE = character(1))
+  has_md <- "md" %in% names
+  has_nomd <- "noMd" %in% names
+
+  md <- global_options$markdown %||% markdown_global_default
+  if (has_md) md <- TRUE
+  if (has_nomd) md <- FALSE
+  markdown_on(md)
+
+  if (has_md && has_nomd) {
+    warning(
+      "Both @md and @noMd, no markdown parsing, in block at ",
+      file, ":", offset
+    )
+  }
 
   tags <- parse_description(tags)
   tags <- compact(lapply(tags, parse_tag, registry = registry))

--- a/R/rd-template.R
+++ b/R/rd-template.R
@@ -13,7 +13,7 @@ template_eval <- function(template_path, vars) {
   utils::capture.output(brew::brew(template_path, envir = vars))
 }
 
-process_templates <- function(block, base_path) {
+process_templates <- function(block, base_path, global_options = list()) {
   template_locs <- names(block) == "template"
   template_tags <- block[template_locs]
   if (length(template_tags) == 0) return(block)
@@ -32,7 +32,8 @@ process_templates <- function(block, base_path) {
   # Insert templates back in the location where they came from
   block_pieces <- lapply(block, list)
   block_pieces[template_locs] <- lapply(results, parse_block,
-    file = "TEMPLATE", registry = roclet_tags.roclet_rd(list()), offset = 0L)
+    file = "TEMPLATE", registry = roclet_tags.roclet_rd(list()), offset = 0L,
+    global_options = global_options)
   names(block_pieces)[template_locs] <- ""
 
   unlist(block_pieces, recursive = FALSE)

--- a/R/rd.R
+++ b/R/rd.R
@@ -39,6 +39,7 @@ roclet_tags.roclet_rd <- function(x) {
     method = tag_words(2, 2),
     name = tag_value,
     md = tag_toggle,
+    noMd = tag_toggle,
     noRd = tag_toggle,
     note = tag_markdown,
     param = tag_name_description,
@@ -58,7 +59,8 @@ roclet_tags.roclet_rd <- function(x) {
 }
 
 #' @export
-roclet_process.roclet_rd <- function(x, parsed, base_path) {
+roclet_process.roclet_rd <- function(x, parsed, base_path,
+                                     global_options = list()) {
   # Convert each block into a topic, indexed by filename
   topics <- RoxyTopics$new()
 
@@ -66,7 +68,7 @@ roclet_process.roclet_rd <- function(x, parsed, base_path) {
     if (length(block) == 0)
       next
 
-    rd <- block_to_rd(block, base_path, parsed$env)
+    rd <- block_to_rd(block, base_path, parsed$env, global_options)
     topics$add(rd)
   }
   topics$drop_invalid()
@@ -77,9 +79,9 @@ roclet_process.roclet_rd <- function(x, parsed, base_path) {
   topics$topics
 }
 
-block_to_rd <- function(block, base_path, env) {
+block_to_rd <- function(block, base_path, env, global_options = list()) {
   # Must start by processing templates
-  block <- process_templates(block, base_path)
+  block <- process_templates(block, base_path, global_options)
 
   if (!needs_doc(block)) {
     return()

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -29,7 +29,7 @@ roclet_tags <- function(x) {
 
 #' @export
 #' @rdname roclet
-roclet_process <- function(x, parsed, base_path) {
+roclet_process <- function(x, parsed, base_path, global_options = list()) {
   UseMethod("roclet_process")
 }
 
@@ -88,13 +88,15 @@ is.roclet <- function(x) inherits(x, "roclet")
 #' @param roclet Name of roclet to use for processing.
 #' @param input Source string
 #' @param registry Named list of tag parsers
+#' @param global_options List of global options
 #' @export
 #' @keywords internal
-roc_proc_text <- function(roclet, input, registry = default_tags()) {
+roc_proc_text <- function(roclet, input, registry = default_tags(),
+                          global_options = list()) {
   stopifnot(is.roclet(roclet))
 
-  parsed <- parse_text(input, registry = registry)
-  roclet_process(roclet, parsed, base_path = ".")
+  parsed <- parse_text(input, registry = registry, global_options)
+  roclet_process(roclet, parsed, base_path = ".", global_options)
 }
 
 default_tags <- function() {

--- a/R/roclet.R
+++ b/R/roclet.R
@@ -6,7 +6,6 @@
 #'
 #' @keywords internal
 #' @name roclet
-#' @md
 NULL
 
 #' @export

--- a/R/roxygenize.R
+++ b/R/roxygenize.R
@@ -62,7 +62,7 @@ roxygenize <- function(package.dir = ".",
   tags <- c(lapply(roclets, roclet_tags), list(list(include = tag_value)))
   registry <- unlist(tags, recursive = FALSE)
 
-  parsed <- parse_package(base_path, load_code, registry)
+  parsed <- parse_package(base_path, load_code, registry, options)
 
   roc_out <- function(roc) {
     if (clean) {
@@ -95,7 +95,8 @@ load_options <- function(base_path = ".") {
 
   defaults <- list(
     wrap = FALSE,
-    roclets = c("collate", "namespace", "rd")
+    roclets = c("collate", "namespace", "rd"),
+    markdown = markdown_global_default
   )
 
   unknown_opts <- setdiff(names(opts), names(defaults))

--- a/R/source.R
+++ b/R/source.R
@@ -9,7 +9,6 @@
 #' @return An environment, into which all R files in the directory were
 #'   sourced.
 #' @keywords internal
-#' @md
 source_package <- function(path) {
   r_path <- file.path(path, "R")
   if (!file.exists(r_path)) stop("Can't find R/ directory", call. = FALSE)

--- a/R/tag.R
+++ b/R/tag.R
@@ -10,7 +10,6 @@
 #' tag parsing generator functions.
 #'
 #' @keywords internal
-#' @md
 #' @export
 #' @param tag Tag name
 #' @param val Tag value. When read from the file, this will be a string,

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -19,7 +19,8 @@ vignette_roclet <- function() {
 }
 
 #' @export
-roclet_process.roclet_vignette <- function(x, parsed, base_path) {
+roclet_process.roclet_vignette <- function(x, parsed, base_path,
+                                           global_options = list()) {
 }
 
 #' @export

--- a/R/vignette.R
+++ b/R/vignette.R
@@ -11,7 +11,6 @@
 #' your package, add `--no-build-vignettes` to the "Build Source Package"
 #' field in your project options.
 #'
-#' @md
 #' @family roclets
 #' @export
 vignette_roclet <- function() {

--- a/man/double_escape_md.Rd
+++ b/man/double_escape_md.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/markdown-escaping.R
 \name{double_escape_md}
 \alias{double_escape_md}
-\title{Escape \\% and \\$ and \\_ once more, because commonmark
+\title{Escape \% and \$ and \_ once more, because commonmark
 removes the escaping. We do this everywhere currently.}
 \usage{
 double_escape_md(text)
@@ -14,7 +14,7 @@ double_escape_md(text)
 Double-escaped text.
 }
 \description{
-Escape \\% and \\$ and \\_ once more, because commonmark
+Escape \% and \$ and \_ once more, because commonmark
 removes the escaping. We do this everywhere currently.
 }
 

--- a/man/roc_proc_text.Rd
+++ b/man/roc_proc_text.Rd
@@ -4,7 +4,8 @@
 \alias{roc_proc_text}
 \title{Process roclet on string and capture results.}
 \usage{
-roc_proc_text(roclet, input, registry = default_tags())
+roc_proc_text(roclet, input, registry = default_tags(),
+  global_options = list())
 }
 \arguments{
 \item{roclet}{Name of roclet to use for processing.}
@@ -12,6 +13,8 @@ roc_proc_text(roclet, input, registry = default_tags())
 \item{input}{Source string}
 
 \item{registry}{Named list of tag parsers}
+
+\item{global_options}{List of global options}
 }
 \description{
 Useful for testing.

--- a/man/roclet.Rd
+++ b/man/roclet.Rd
@@ -14,7 +14,7 @@ roclet_output(x, results, base_path, ...)
 
 roclet_tags(x)
 
-roclet_process(x, parsed, base_path)
+roclet_process(x, parsed, base_path, global_options)
 
 roclet_clean(x, base_path)
 }

--- a/man/roxygen2-package.Rd
+++ b/man/roxygen2-package.Rd
@@ -25,8 +25,8 @@ Maintainer: Hadley Wickham \email{h.wickham@gmail.com}
 }
 \seealso{
 See \code{vignette("roxygen2", package = "roxygen2")} for an overview
-  of the package, \code{vignette("rd", package = "roxygen2")} for generating
-  documentation, and \code{vignette("namespace", package = "roxygen2")} for
-  generating the namespace specification.
+of the package, \code{vignette("rd", package = "roxygen2")} for generating
+documentation, and \code{vignette("namespace", package = "roxygen2")} for
+generating the namespace specification.
 }
 

--- a/tests/testthat/test-rd-markdown-on-off.R
+++ b/tests/testthat/test-rd-markdown-on-off.R
@@ -1,0 +1,126 @@
+context("Rd: turning markdown on/off")
+roc <- rd_roclet()
+
+test_that("turning on/off markdown globally", {
+  ## off
+  out1 <- roc_proc_text(roc, global_options = list(markdown = FALSE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+  ## on
+  out1 <- roc_proc_text(roc, global_options = list(markdown = TRUE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some \\code{code} included. \\code{More code.}"
+  )
+})
+
+test_that("turning on/off markdown locally", {
+  ## off / off
+  out1 <- roc_proc_text(roc, global_options = list(markdown = FALSE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    #' @noMd
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+  ## off / on
+  out1 <- roc_proc_text(roc, global_options = list(markdown = FALSE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    #' @md
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some \\code{code} included. \\code{More code.}"
+  )
+
+  ## on / off
+  out1 <- roc_proc_text(roc, global_options = list(markdown = TRUE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    #' @noMd
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+  ## on / on
+  out1 <- roc_proc_text(roc, global_options = list(markdown = TRUE), "
+    #' Title
+    #'
+    #' Description with some `code` included. `More code.`
+    #' @md
+    foo <- function() {}")[[1]]
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some \\code{code} included. \\code{More code.}"
+  )
+
+})
+
+test_that("warning for both @md and @noMd", {
+
+  expect_warning(
+    out1 <- roc_proc_text(roc, "
+      #' Title
+      #'
+      #' Description with some `code` included. `More code.`
+      #' @md
+      #' @noMd
+      foo <- function() {}")[[1]],
+    "Both @md and @noMd, no markdown parsing"
+  )
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+  expect_warning(
+    out1 <- roc_proc_text(roc, global_options = list(markdown = FALSE), "
+      #' Title
+      #'
+      #' Description with some `code` included. `More code.`
+      #' @md
+      #' @noMd
+      foo <- function() {}")[[1]],
+    "Both @md and @noMd, no markdown parsing"
+  )
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+  expect_warning(
+    out1 <- roc_proc_text(roc, global_options = list(markdown = TRUE), "
+      #' Title
+      #'
+      #' Description with some `code` included. `More code.`
+      #' @md
+      #' @noMd
+      foo <- function() {}")[[1]],
+    "Both @md and @noMd, no markdown parsing"
+  )
+  expect_equal(
+    get_tag(out1, "description")$values,
+    "Description with some `code` included. `More code.`"
+  )
+
+})

--- a/vignettes/markdown.Rmd
+++ b/vignettes/markdown.Rmd
@@ -19,7 +19,17 @@ Starting from version 6.0.0, roxygen supports markdown markup within most roxyge
 
 # Turning on markdown support
 
-Currently you have to turn on markdown formatting manually for each roxygen chunk. You can do this by using the `@md` tag anywhere in the chunk. In the future roxygen will provide a global switch that turns on markdown formatting for the whole package. (And also a `@noMd` to turn it off, optionally.)
+There are two ways to turn on markdown support for a package: globally, at the package level, and locally at the block level.
+
+To turn on markdown for the whole package, insert this entry into the `DESCRIPTION` file of the package:
+```
+Roxygen: list(markdown = TRUE)
+```
+The position of the entry in the file does not matter. After this, all Roxygen documentation will be parsed as markdown.
+
+Alternatively, you can use the `@md` tag to turn on markdown support for a single documentation chunk. This is a good option to write any new documentation for existing packages in markdown.
+
+There is also a new `@noMd` tag. Use this if you turned on markdown parsing globally, but need to avoid it for a single chunk. This tag is handy if the markdown parser interferes with more complex Rd syntax.
 
 Here is an example roxygen chunk that uses markdown.
 
@@ -168,7 +178,7 @@ The parser recognizes the markdown notation for embedded images. The image files
 
 # Roxygen and Rd tags *not* parsed as markdown
 
-Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
+Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noMd`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
 
 When mixing `Rd` and markdown notation, most `Rd` tags may contain markdown markup, the ones that can *not* are: `r paste0("\x60", roxygen2:::escaped_for_md, "\x60", collapse = ", ")`.
 

--- a/vignettes/markdown.html
+++ b/vignettes/markdown.html
@@ -1,190 +1,221 @@
----
-title: "Write R Documentation in Markdown"
-author: "Gábor Csárdi"
-date: "2016-09-18"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Write R Documentation in Markdown}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
----
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<meta name="author" content="Gábor Csárdi" />
+
+<meta name="date" content="2016-09-22" />
+
+<title>Write R Documentation in Markdown</title>
 
 
 
-# Introduction
+<style type="text/css">code{white-space: pre;}</style>
+<style type="text/css">
+div.sourceCode { overflow-x: auto; }
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code > span.dt { color: #902000; } /* DataType */
+code > span.dv { color: #40a070; } /* DecVal */
+code > span.bn { color: #40a070; } /* BaseN */
+code > span.fl { color: #40a070; } /* Float */
+code > span.ch { color: #4070a0; } /* Char */
+code > span.st { color: #4070a0; } /* String */
+code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code > span.ot { color: #007020; } /* Other */
+code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code > span.fu { color: #06287e; } /* Function */
+code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+code > span.cn { color: #880000; } /* Constant */
+code > span.sc { color: #4070a0; } /* SpecialChar */
+code > span.vs { color: #4070a0; } /* VerbatimString */
+code > span.ss { color: #bb6688; } /* SpecialString */
+code > span.im { } /* Import */
+code > span.va { color: #19177c; } /* Variable */
+code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code > span.op { color: #666666; } /* Operator */
+code > span.bu { } /* BuiltIn */
+code > span.ex { } /* Extension */
+code > span.pp { color: #bc7a00; } /* Preprocessor */
+code > span.at { color: #7d9029; } /* Attribute */
+code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+</style>
 
-Starting from version 6.0.0, roxygen supports markdown markup within most roxygen tags. Roxygen uses the `commonmark` package, which is based on the CommonMark Reference Implementation to parse these tags. See http://commonmark.org/help/ for more about the parser and the markdown language it supports.
 
-# Turning on markdown support
 
-Currently you have to turn on markdown formatting manually for each roxygen chunk. You can do this by using the `@md` tag anywhere in the chunk. In the future roxygen will provide a global switch that turns on markdown formatting for the whole package. (And also a `@noMd` to turn it off, optionally.)
+<link href="data:text/css;charset=utf-8,body%20%7B%0Abackground%2Dcolor%3A%20%23fff%3B%0Amargin%3A%201em%20auto%3B%0Amax%2Dwidth%3A%20700px%3B%0Aoverflow%3A%20visible%3B%0Apadding%2Dleft%3A%202em%3B%0Apadding%2Dright%3A%202em%3B%0Afont%2Dfamily%3A%20%22Open%20Sans%22%2C%20%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans%2Dserif%3B%0Afont%2Dsize%3A%2014px%3B%0Aline%2Dheight%3A%201%2E35%3B%0A%7D%0A%23header%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0A%23TOC%20%7B%0Aclear%3A%20both%3B%0Amargin%3A%200%200%2010px%2010px%3B%0Apadding%3A%204px%3B%0Awidth%3A%20400px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Aborder%2Dradius%3A%205px%3B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Afont%2Dsize%3A%2013px%3B%0Aline%2Dheight%3A%201%2E3%3B%0A%7D%0A%23TOC%20%2Etoctitle%20%7B%0Afont%2Dweight%3A%20bold%3B%0Afont%2Dsize%3A%2015px%3B%0Amargin%2Dleft%3A%205px%3B%0A%7D%0A%23TOC%20ul%20%7B%0Apadding%2Dleft%3A%2040px%3B%0Amargin%2Dleft%3A%20%2D1%2E5em%3B%0Amargin%2Dtop%3A%205px%3B%0Amargin%2Dbottom%3A%205px%3B%0A%7D%0A%23TOC%20ul%20ul%20%7B%0Amargin%2Dleft%3A%20%2D2em%3B%0A%7D%0A%23TOC%20li%20%7B%0Aline%2Dheight%3A%2016px%3B%0A%7D%0Atable%20%7B%0Amargin%3A%201em%20auto%3B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dcolor%3A%20%23DDDDDD%3B%0Aborder%2Dstyle%3A%20outset%3B%0Aborder%2Dcollapse%3A%20collapse%3B%0A%7D%0Atable%20th%20%7B%0Aborder%2Dwidth%3A%202px%3B%0Apadding%3A%205px%3B%0Aborder%2Dstyle%3A%20inset%3B%0A%7D%0Atable%20td%20%7B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dstyle%3A%20inset%3B%0Aline%2Dheight%3A%2018px%3B%0Apadding%3A%205px%205px%3B%0A%7D%0Atable%2C%20table%20th%2C%20table%20td%20%7B%0Aborder%2Dleft%2Dstyle%3A%20none%3B%0Aborder%2Dright%2Dstyle%3A%20none%3B%0A%7D%0Atable%20thead%2C%20table%20tr%2Eeven%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Ap%20%7B%0Amargin%3A%200%2E5em%200%3B%0A%7D%0Ablockquote%20%7B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Apadding%3A%200%2E25em%200%2E75em%3B%0A%7D%0Ahr%20%7B%0Aborder%2Dstyle%3A%20solid%3B%0Aborder%3A%20none%3B%0Aborder%2Dtop%3A%201px%20solid%20%23777%3B%0Amargin%3A%2028px%200%3B%0A%7D%0Adl%20%7B%0Amargin%2Dleft%3A%200%3B%0A%7D%0Adl%20dd%20%7B%0Amargin%2Dbottom%3A%2013px%3B%0Amargin%2Dleft%3A%2013px%3B%0A%7D%0Adl%20dt%20%7B%0Afont%2Dweight%3A%20bold%3B%0A%7D%0Aul%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Aul%20li%20%7B%0Alist%2Dstyle%3A%20circle%20outside%3B%0A%7D%0Aul%20ul%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0Apre%2C%20code%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0Aborder%2Dradius%3A%203px%3B%0Acolor%3A%20%23333%3B%0Awhite%2Dspace%3A%20pre%2Dwrap%3B%20%0A%7D%0Apre%20%7B%0Aborder%2Dradius%3A%203px%3B%0Amargin%3A%205px%200px%2010px%200px%3B%0Apadding%3A%2010px%3B%0A%7D%0Apre%3Anot%28%5Bclass%5D%29%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Acode%20%7B%0Afont%2Dfamily%3A%20Consolas%2C%20Monaco%2C%20%27Courier%20New%27%2C%20monospace%3B%0Afont%2Dsize%3A%2085%25%3B%0A%7D%0Ap%20%3E%20code%2C%20li%20%3E%20code%20%7B%0Apadding%3A%202px%200px%3B%0A%7D%0Adiv%2Efigure%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0Aimg%20%7B%0Abackground%2Dcolor%3A%20%23FFFFFF%3B%0Apadding%3A%202px%3B%0Aborder%3A%201px%20solid%20%23DDDDDD%3B%0Aborder%2Dradius%3A%203px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Amargin%3A%200%205px%3B%0A%7D%0Ah1%20%7B%0Amargin%2Dtop%3A%200%3B%0Afont%2Dsize%3A%2035px%3B%0Aline%2Dheight%3A%2040px%3B%0A%7D%0Ah2%20%7B%0Aborder%2Dbottom%3A%204px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Apadding%2Dbottom%3A%202px%3B%0Afont%2Dsize%3A%20145%25%3B%0A%7D%0Ah3%20%7B%0Aborder%2Dbottom%3A%202px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Afont%2Dsize%3A%20120%25%3B%0A%7D%0Ah4%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23f7f7f7%3B%0Amargin%2Dleft%3A%208px%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Ah5%2C%20h6%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23ccc%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Aa%20%7B%0Acolor%3A%20%230033dd%3B%0Atext%2Ddecoration%3A%20none%3B%0A%7D%0Aa%3Ahover%20%7B%0Acolor%3A%20%236666ff%3B%20%7D%0Aa%3Avisited%20%7B%0Acolor%3A%20%23800080%3B%20%7D%0Aa%3Avisited%3Ahover%20%7B%0Acolor%3A%20%23BB00BB%3B%20%7D%0Aa%5Bhref%5E%3D%22http%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0Aa%5Bhref%5E%3D%22https%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0A%0Acode%20%3E%20span%2Ekw%20%7B%20color%3A%20%23555%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Edt%20%7B%20color%3A%20%23902000%3B%20%7D%20%0Acode%20%3E%20span%2Edv%20%7B%20color%3A%20%2340a070%3B%20%7D%20%0Acode%20%3E%20span%2Ebn%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Efl%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Ech%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Est%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Eco%20%7B%20color%3A%20%23888888%3B%20font%2Dstyle%3A%20italic%3B%20%7D%20%0Acode%20%3E%20span%2Eot%20%7B%20color%3A%20%23007020%3B%20%7D%20%0Acode%20%3E%20span%2Eal%20%7B%20color%3A%20%23ff0000%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Efu%20%7B%20color%3A%20%23900%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%20code%20%3E%20span%2Eer%20%7B%20color%3A%20%23a61717%3B%20background%2Dcolor%3A%20%23e3d2d2%3B%20%7D%20%0A" rel="stylesheet" type="text/css" />
 
-Here is an example roxygen chunk that uses markdown.
+</head>
 
-```r
-#' Use roxygen to document a package.
-#'
-#' This function is a wrapper for the [roxygen2::roxygenize()] function from
-#' the `roxygen2` package. See the documentation and vignettes of
-#' that package to learn how to use roxygen.
-#'
-#' @param pkg package description, can be path or package name.  See
-#'   [as.package()] for more information
-#' @param clean,reload Deprecated.
-#' @inheritParams roxygen2::roxygenise
-#' @seealso [roxygen2::roxygenize()], `browseVignettes("roxygen2")`
-#' @export
-#' @md
-```
+<body>
 
-# Syntax
 
-## Emphasis
 
-*Emphasis* and **strong** (bold) text are supported. For emphasis, put the text between asterisks or underline characters. For strong text, use two asterisks at both sides.
 
-```r
-#' See `::is_falsy` for the definition of what is _falsy_
-#' and what is _truthy_.
-```
+<h1 class="title toc-ignore">Write R Documentation in Markdown</h1>
+<h4 class="author"><em>Gábor Csárdi</em></h4>
+<h4 class="date"><em>2016-09-22</em></h4>
 
-```r
-#' @references
-#' Robert E Tarjan and Mihalis Yannakakis. (1984). Simple
 
-#' linear-time algorithms to test chordality of graphs, test acyclicity
-#' of hypergraphs, and selectively reduce acyclic hypergraphs.
-#' *SIAM Journal of Computation* **13**, 566-579.
-```
 
-## Code
+<div id="introduction" class="section level1">
+<h1>Introduction</h1>
+<p>Starting from version 6.0.0, roxygen supports markdown markup within most roxygen tags. Roxygen uses the <code>commonmark</code> package, which is based on the CommonMark Reference Implementation to parse these tags. See <a href="http://commonmark.org/help/" class="uri">http://commonmark.org/help/</a> for more about the parser and the markdown language it supports.</p>
+</div>
+<div id="turning-on-markdown-support" class="section level1">
+<h1>Turning on markdown support</h1>
+<p>There are two ways to turn on markdown support for a package: globally, at the package level, and locally at the block level.</p>
+<p>To turn on markdown for the whole package, insert this entry into the <code>DESCRIPTION</code> file of the package:</p>
+<pre><code>Roxygen: list(markdown = TRUE)</code></pre>
+<p>The position of the entry in the file does not matter. After this, all Roxygen documentation will be parsed as markdown.</p>
+<p>Alternatively, you can use the <code>@md</code> tag to turn on markdown support for a single documentation chunk. This is a good option to write any new documentation for existing packages in markdown.</p>
+<p>There is also a new <code>@noMd</code> tag. Use this if you turned on markdown parsing globally, but need to avoid it for a single chunk. This tag is handy if the markdown parser interferes with more complex Rd syntax.</p>
+<p>Here is an example roxygen chunk that uses markdown.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' Use roxygen to document a package.</span>
+<span class="co">#'</span>
+<span class="co">#' This function is a wrapper for the [roxygen2::roxygenize()] function from</span>
+<span class="co">#' the `roxygen2` package. See the documentation and vignettes of</span>
+<span class="co">#' that package to learn how to use roxygen.</span>
+<span class="co">#'</span>
+<span class="co">#' @param pkg package description, can be path or package name.  See</span>
+<span class="co">#'   [as.package()] for more information</span>
+<span class="co">#' @param clean,reload Deprecated.</span>
+<span class="co">#' @inheritParams roxygen2::roxygenise</span>
+<span class="co">#' @seealso [roxygen2::roxygenize()], `browseVignettes(&quot;roxygen2&quot;)`</span>
+<span class="co">#' @export</span>
+<span class="co">#' @md</span></code></pre></div>
+</div>
+<div id="syntax" class="section level1">
+<h1>Syntax</h1>
+<div id="emphasis" class="section level2">
+<h2>Emphasis</h2>
+<p><em>Emphasis</em> and <strong>strong</strong> (bold) text are supported. For emphasis, put the text between asterisks or underline characters. For strong text, use two asterisks at both sides.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' See `::is_falsy` for the definition of what is _falsy_</span>
+<span class="co">#' and what is _truthy_.</span></code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' @references</span>
+<span class="co">#' Robert E Tarjan and Mihalis Yannakakis. (1984). Simple</span>
 
-Inline code is supported via backticks.
+<span class="co">#' linear-time algorithms to test chordality of graphs, test acyclicity</span>
+<span class="co">#' of hypergraphs, and selectively reduce acyclic hypergraphs.</span>
+<span class="co">#' *SIAM Journal of Computation* **13**, 566-579.</span></code></pre></div>
+</div>
+<div id="code" class="section level2">
+<h2>Code</h2>
+<p>Inline code is supported via backticks.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' @param ns Optionally, a named vector giving prefix-url pairs, as</span>
+<span class="co">#'   produced by `xml_ns`. If provided, all names will be explicitly</span>
+<span class="co">#'   qualified with the ns prefix, i.e. if the element `bar` is defined ...</span></code></pre></div>
+<p>For blocks of code, put your code between triple backticks:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' ```</span>
+<span class="co">#' pkg &lt;- make_packages(</span>
+<span class="co">#'   foo1 = { f &lt;- function() print(&quot;hello!&quot;) ; d &lt;- 1:10 },</span>
+<span class="co">#'   foo2 = { f &lt;- function() print(&quot;hello again!&quot;) ; d &lt;- 11:20 }</span>
+<span class="co">#' )</span>
+<span class="co">#' foo1::f()</span>
+<span class="co">#' foo2::f()</span>
+<span class="co">#' foo1::d</span>
+<span class="co">#' foo2::d</span>
+<span class="co">#' dispose_packages(pkg)</span>
+<span class="co">#' ```</span></code></pre></div>
+<p>Note that this is not needed in <code>@examples</code>, since its contents is formatted as R code, anyway.</p>
+</div>
+<div id="lists" class="section level2">
+<h2>Lists</h2>
+<p>Regular Markdown lists are recognized and converted to <code>\enumerate{}</code> or <code>\itemize{}</code> lists:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' There are two ways to use this function:</span>
+<span class="co">#' 1. If its first argument is not named, then it returns a function</span>
+<span class="co">#'    that can be used to color strings.</span>
+<span class="co">#' 1. If its first argument is named, then it also creates a</span>
+<span class="co">#'    style with the given name. This style can be used in</span>
+<span class="co">#'    `style`. One can still use the return value</span>
+<span class="co">#'    of the function, to create a style function.</span></code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' The style (the `...` argument) can be anything of the</span>
+<span class="co">#' following:</span>
+<span class="co">#' * An R color name, see `colors()`.</span>
+<span class="co">#' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means</span>
+<span class="co">#'   red. Transparency (alpha channel) values are ignored.</span>
+<span class="co">#' * A one-column matrix with three rows for the red, green</span>
+<span class="co">#'   and blue channels, as returned by [grDevices::col2rgb()]</span></code></pre></div>
+<p>Nested lists are also supported.</p>
+<p>Note that you do not have leave an empty line before the list. This is different from some markdown parsers.</p>
+</div>
+<div id="links" class="section level2">
+<h2>Links</h2>
+<p>Markdown hyperlinks work as usual:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' See more about the markdown markup at the</span>
+<span class="co">#' [Commonmark web site](http://commonmark.org/help)</span></code></pre></div>
+<p>URLs are also automatically converted to hyperlinks:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' The main R web site is at https://r-project.org.</span></code></pre></div>
+<p>Markdown notation can be used to create links to other manual pages. There are six kinds of links:</p>
+<ol style="list-style-type: decimal">
+<li>Link to another function in the same package: <code>[func()]</code>. These links will be typeset as code, and they are equavalent to <code>\code{\link[=func]{func()}</code>.</li>
+<li>Link to a (non-function) object, class, data set, etc. in the same same package: <code>[object]</code>. These links that <em>not</em> typeset as code, so if you want them as code, enclose them in backticks (inside the brackets).</li>
+<li>Link to a function from another package: <code>[pkg::func()]</code>. These links will be typeset as code.</li>
+<li>Link to a (non-function) object in another package: <code>[pkg::object]</code>. These links will not be typeset as code.</li>
+<li>Link to an object in the same package, with a different link text: <code>[link text][object]</code>. Here <code>object</code> can be a function, but the link text is not typeset as code.</li>
+<li>Link to an object in another package, with different link text: <code>[link text][pkg:object]</code>. This is not typeset as code.</li>
+</ol>
+<p>S3/S4 classes can be linked the same way:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' * [terms][terms.object] becomes \link[=terms.object]{terms}</span>
+<span class="co">#' * [abc][abc-class] becomes \link[=abc-class]{abc}</span></code></pre></div>
+</div>
+<div id="images" class="section level2">
+<h2>Images</h2>
+<p>The parser recognizes the markdown notation for embedded images. The image files must in the <code>man/figures</code> directory:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' Here is an example plot:</span>
+<span class="co">#' ![](example-plot.jpg &quot;Example Plot Title&quot;)</span></code></pre></div>
+</div>
+</div>
+<div id="roxygen-and-rd-tags-not-parsed-as-markdown" class="section level1">
+<h1>Roxygen and Rd tags <em>not</em> parsed as markdown</h1>
+<p>Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: <code>@aliases</code>, <code>@backref</code>, <code>@docType</code>, <code>@encoding</code>, <code>@evalRd</code>, <code>@example</code>, <code>@examples</code>, <code>@family</code>, <code>@inheritParams</code>, <code>@keywords</code>, <code>@method</code> <code>@name</code>, <code>@md</code>, <code>@noMd</code>, <code>@noRd</code>, <code>@rdname</code>, <code>@rawRd</code>, <code>@usage</code>.</p>
+<p>When mixing <code>Rd</code> and markdown notation, most <code>Rd</code> tags may contain markdown markup, the ones that can <em>not</em> are: <code>\acronym</code>, <code>\code</code>, <code>\command</code>, <code>\CRANpkg</code>, <code>\deqn</code>, <code>\doi</code>, <code>\dontrun</code>, <code>\dontshow</code>, <code>\donttest</code>, <code>\email</code>, <code>\env</code>, <code>\eqn</code>, <code>\figure</code>, <code>\file</code>, <code>\if</code>, <code>\ifelse</code>, <code>\kbd</code>, <code>\link</code>, <code>\linkS4class</code>, <code>\method</code>, <code>\newcommand</code>, <code>\option</code>, <code>\out</code>, <code>\packageAuthor</code>, <code>\packageDescription</code>, <code>\packageDESCRIPTION</code>, <code>\packageIndices</code>, <code>\packageMaintainer</code>, <code>\packageTitle</code>, <code>\pkg</code>, <code>\PR</code>, <code>\preformatted</code>, <code>\renewcommand</code>, <code>\S3method</code>, <code>\S4method</code>, <code>\samp</code>, <code>\special</code>, <code>\testonly</code>, <code>\url</code>, <code>\var</code>, <code>\verb</code>.</p>
+</div>
+<div id="possible-problems" class="section level1">
+<h1>Possible problems</h1>
+<div id="mixing-markdown-and-rd-markup" class="section level2">
+<h2>Mixing markdown and <code>Rd</code> markup</h2>
+<p>Note that turning on markdown does <em>not</em> turn off the standard <code>Rd</code> syntax. We suggest that you use the regular <code>Rd</code> tags in a markdown roxygen chunk only if necessary. The two parsers do occasionally interact, and the markdown parser can pick up and reformat Rd syntax, causing an error, or currupted manuals.</p>
+</div>
+<div id="leading-whitespace" class="section level2">
+<h2>Leading whitespace</h2>
+<p>Leading whitespace is interpreted by the commonmark parser, whereas it is ignored by the <code>Rd</code> parser (except in <code>\preformatted{}</code>). Make sure that you only include leading whitespace intentionally, for example for nested lists.</p>
+</div>
+<div id="spurious-lists" class="section level2">
+<h2>Spurious lists</h2>
+<p>The Commonmark parser does not require an empty line before lists, and this might lead to unintended lists if a line starts with a number followed by a dot, or with an asterisk followed by whitespace:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' You can see more about this topic in the book cited below, on page</span>
+<span class="co">#' 42. Clearly, the numbered list that starts here is not intentional.</span></code></pre></div>
+</div>
+</div>
 
-```r
-#' @param ns Optionally, a named vector giving prefix-url pairs, as
-#'   produced by `xml_ns`. If provided, all names will be explicitly
-#'   qualified with the ns prefix, i.e. if the element `bar` is defined ...
-```
 
-For blocks of code, put your code between triple backticks:
 
-```r
-#' ```
-#' pkg <- make_packages(
-#'   foo1 = { f <- function() print("hello!") ; d <- 1:10 },
-#'   foo2 = { f <- function() print("hello again!") ; d <- 11:20 }
-#' )
-#' foo1::f()
-#' foo2::f()
-#' foo1::d
-#' foo2::d
-#' dispose_packages(pkg)
-#' ```
-```
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
 
-Note that this is not needed in `@examples`, since its contents is formatted as R code,
-anyway.
-
-## Lists
-
-Regular Markdown lists are recognized and converted to `\enumerate{}` or `\itemize{}` lists:
-
-```r
-#' There are two ways to use this function:
-#' 1. If its first argument is not named, then it returns a function
-#'    that can be used to color strings.
-#' 1. If its first argument is named, then it also creates a
-#'    style with the given name. This style can be used in
-#'    `style`. One can still use the return value
-#'    of the function, to create a style function.
-```
-
-```r
-#' The style (the `...` argument) can be anything of the
-#' following:
-#' * An R color name, see `colors()`.
-#' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means
-#'   red. Transparency (alpha channel) values are ignored.
-#' * A one-column matrix with three rows for the red, green
-#'   and blue channels, as returned by [grDevices::col2rgb()]
-```
-
-Nested lists are also supported.
-
-Note that you do not have leave an empty line before the list. This is different from some markdown parsers.
-
-## Links
-
-Markdown hyperlinks work as usual:
-
-```r
-#' See more about the markdown markup at the
-#' [Commonmark web site](http://commonmark.org/help)
-```
-
-URLs are also automatically converted to hyperlinks:
-
-```r
-#' The main R web site is at https://r-project.org.
-```
-
-Markdown notation can be used to create links to other manual pages. There are six kinds of links:
-
-1. Link to another function in the same package: `[func()]`. These
-   links will be typeset as code, and they are equavalent to
-   `\code{\link[=func]{func()}`.
-2. Link to a (non-function) object, class, data set, etc. in the same
-   same package: `[object]`. These links that *not* typeset as code,
-   so if you want them as code, enclose them in backticks (inside the
-   brackets).
-3. Link to a function from another package: `[pkg::func()]`. These links
-   will be typeset as code.
-4. Link to a (non-function) object in another package: `[pkg::object]`.
-   These links will not be typeset as code.
-5. Link to an object in the same package, with a different link text:
-   `[link text][object]`. Here `object` can be a function, but the link
-   text is not typeset as code.
-6. Link to an object in another package, with different link text:
-   `[link text][pkg:object]`. This is not typeset as code.
-
-S3/S4 classes can be linked the same way:
-
-```r
-#' * [terms][terms.object] becomes \link[=terms.object]{terms}
-#' * [abc][abc-class] becomes \link[=abc-class]{abc}
-```
-
-## Images
-
-The parser recognizes the markdown notation for embedded images. The image files must in the  `man/figures` directory:
-
-```r
-#' Here is an example plot:
-#' ![](example-plot.jpg "Example Plot Title")
-```
-
-# Roxygen and Rd tags *not* parsed as markdown
-
-Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
-
-When mixing `Rd` and markdown notation, most `Rd` tags may contain markdown markup, the ones that can *not* are: `\acronym`, `\code`, `\command`, `\CRANpkg`, `\deqn`, `\doi`, `\dontrun`, `\dontshow`, `\donttest`, `\email`, `\env`, `\eqn`, `\figure`, `\file`, `\if`, `\ifelse`, `\kbd`, `\link`, `\linkS4class`, `\method`, `\newcommand`, `\option`, `\out`, `\packageAuthor`, `\packageDescription`, `\packageDESCRIPTION`, `\packageIndices`, `\packageMaintainer`, `\packageTitle`, `\pkg`, `\PR`, `\preformatted`, `\renewcommand`, `\S3method`, `\S4method`, `\samp`, `\special`, `\testonly`, `\url`, `\var`, `\verb`.
-
-# Possible problems
-
-## Mixing markdown and `Rd` markup
-
-Note that turning on markdown does *not* turn off the standard `Rd` syntax. We suggest that you use the regular `Rd` tags in a markdown roxygen chunk only if necessary. The two parsers do occasionally interact, and the markdown parser can pick up and reformat Rd syntax, causing an error, or currupted manuals.
-
-## Leading whitespace
-
-Leading whitespace is interpreted by the commonmark parser, whereas it is ignored by the `Rd` parser (except in `\preformatted{}`). Make sure that you only include leading whitespace intentionally, for example for nested lists.
-
-## Spurious lists
-
-The Commonmark parser does not require an empty line before lists, and this might lead to unintended lists if a line starts with a number followed by a dot, or with an asterisk followed by whitespace:
-
-```r
-#' You can see more about this topic in the book cited below, on page
-#' 42. Clearly, the numbered list that starts here is not intentional.
-```
+</body>
+</html>

--- a/vignettes/markdown.md
+++ b/vignettes/markdown.md
@@ -1,7 +1,7 @@
 ---
 title: "Write R Documentation in Markdown"
 author: "Gábor Csárdi"
-date: "2016-09-18"
+date: "2016-09-22"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Write R Documentation in Markdown}
@@ -17,7 +17,17 @@ Starting from version 6.0.0, roxygen supports markdown markup within most roxyge
 
 # Turning on markdown support
 
-Currently you have to turn on markdown formatting manually for each roxygen chunk. You can do this by using the `@md` tag anywhere in the chunk. In the future roxygen will provide a global switch that turns on markdown formatting for the whole package. (And also a `@noMd` to turn it off, optionally.)
+There are two ways to turn on markdown support for a package: globally, at the package level, and locally at the block level.
+
+To turn on markdown for the whole package, insert this entry into the `DESCRIPTION` file of the package:
+```
+Roxygen: list(markdown = TRUE)
+```
+The position of the entry in the file does not matter. After this, all Roxygen documentation will be parsed as markdown.
+
+Alternatively, you can use the `@md` tag to turn on markdown support for a single documentation chunk. This is a good option to write any new documentation for existing packages in markdown.
+
+There is also a new `@noMd` tag. Use this if you turned on markdown parsing globally, but need to avoid it for a single chunk. This tag is handy if the markdown parser interferes with more complex Rd syntax.
 
 Here is an example roxygen chunk that uses markdown.
 
@@ -166,7 +176,7 @@ The parser recognizes the markdown notation for embedded images. The image files
 
 # Roxygen and Rd tags *not* parsed as markdown
 
-Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
+Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noMd`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
 
 When mixing `Rd` and markdown notation, most `Rd` tags may contain markdown markup, the ones that can *not* are: `\acronym`, `\code`, `\command`, `\CRANpkg`, `\deqn`, `\doi`, `\dontrun`, `\dontshow`, `\donttest`, `\email`, `\env`, `\eqn`, `\figure`, `\file`, `\if`, `\ifelse`, `\kbd`, `\link`, `\linkS4class`, `\method`, `\newcommand`, `\option`, `\out`, `\packageAuthor`, `\packageDescription`, `\packageDESCRIPTION`, `\packageIndices`, `\packageMaintainer`, `\packageTitle`, `\pkg`, `\PR`, `\preformatted`, `\renewcommand`, `\S3method`, `\S4method`, `\samp`, `\special`, `\testonly`, `\url`, `\var`, `\verb`.
 


### PR DESCRIPTION
For #507 

We read the options via the usual `load_options()` in `roxygenize()`, and then push them down the call chain (almost) everywhere. `parse_text()` also gets a `global_options` argument.

In each function where I added the `global_options` argument, I also added a default value (`list()`), so that we don't break other packages.

While this is done, and works, I don't think it is ideal. The best would be to attach the options to some `package` object, and make this reachable from `block` objects. Roxygen does not really have the organization to implement this cleanly, AFAICT.

Another option would be a global options store, but my problem with that is that it is hard to invalidate, and that these options really belong to the package and the blocks, not to roxygen itself. 