### PR TITLE
Support setMethodS3() and setConstructorS3() of R.methodsS3 and R.oo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # roxygen2 5.0.1.9000
 
+* S3 method declarations via setMethodS3() of R.methodS3 and function
+  declarations via setConstructorS3() of R.oo are not supported (#525).
+
 * You can now document `setClassUnion()`s (#514).
 
 * New `@inheritDocParams` allows you to automatically generate parameter 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # roxygen2 5.0.1.9000
 
 * S3 method declarations via setMethodS3() of R.methodS3 and function
-  declarations via setConstructorS3() of R.oo are not supported (#525).
+  declarations via setConstructorS3() of R.oo are now supported (#525).
 
 * You can now document `setClassUnion()`s (#514).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 # roxygen2 5.0.1.9000
 
 * S3 method declarations via setMethodS3() of R.methodS3 and function
-  declarations via setConstructorS3() of R.oo are now supported (#525).
+  declarations via setConstructorS3() of R.oo are now supported
+  (@HenrikBengtsson, #525).
 
 * You can now document `setClassUnion()`s (#514).
 

--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -142,16 +142,13 @@ parser_setMethodS3 <- function(call, env, block) {
   method <- as.character(call[[2]])
   class <- as.character(call[[3]])
   name <- paste(method, class, sep=".")
-  value <- get(name, env)
-  value <- standardise_obj(name, value, env, block)
+  value <- standardise_obj(get(name, env), value, env, block)
   object(value, name)
-
 }
 
 parser_setConstructorS3 <- function(call, env, block) {
   # R.oo::setConstructorS3(name, ...)
   name <- as.character(call[[2]])
-  value <- get(name, env)
-  value <- standardise_obj(name, value, env, block)
+  value <- standardise_obj(get(name, env), value, env, block)
   object(value, name)
 }

--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -136,3 +136,22 @@ parser_setReplaceMethod <- function(call, env, block) {
 
   object(list(pkg = pkg, fun = fun), alias = fun, type = "import")
 }
+
+parser_setMethodS3 <- function(call, env, block) {
+  # R.methodsS3::setMethodS3(name, class, ...)
+  method <- as.character(call[[2]])
+  class <- as.character(call[[3]])
+  name <- paste(method, class, sep=".")
+  value <- get(name, env)
+  value <- standardise_obj(name, value, env, block)
+  object(value, name)
+
+}
+
+parser_setConstructorS3 <- function(call, env, block) {
+  # R.oo::setConstructorS3(name, ...)
+  name <- as.character(call[[2]])
+  value <- get(name, env)
+  value <- standardise_obj(name, value, env, block)
+  object(value, name)
+}

--- a/man/roclet.Rd
+++ b/man/roclet.Rd
@@ -14,7 +14,7 @@ roclet_output(x, results, base_path, ...)
 
 roclet_tags(x)
 
-roclet_process(x, parsed, base_path, global_options)
+roclet_process(x, parsed, base_path, global_options = list())
 
 roclet_clean(x, base_path)
 }


### PR DESCRIPTION
`R.methodsS3::setMethodS3(name, class, definition)` defines S3 method `name.class <- definition` and `R.oo::setConstructorS3(name, definition)` defines R function `name <- definition`.  With this patch, roxygen2 recognizes the above constructors accordingly.

For the records, the background for this PR is private email 'R.methodsS3 with roxygen2' on 2016-10-03 from @martynplummer to me and @hadley (cc: @Lucaweihs and Mathias Drton).  The patch has been validated by me and independently by @martynplummer.
