### PR TITLE
tag_two_part first part is not parsed as markdown

### DIFF
--- a/R/tag.R
+++ b/R/tag.R
@@ -122,9 +122,16 @@ tag_name <- function(x) {
 #'   (FALSE)?
 tag_two_part <- function(first, second, required = TRUE) {
 
-  function(x) {
-    x$val <- full_markdown(x$val)
+  ## For now we parse only the second part as markdown, because
+  ## * for all current use cases, coming from tag_name_description
+  ##   (describeIn, field, inheritSection, param, slot, templateVar),
+  ##   this is the right thing to do, and
+  ## * if the two-part tag generally consists of a name and a
+  ##   description, then this is a sensible default.
+  ## In the future we might need extra arguments to this function to
+  ## override this behavior
 
+  function(x) {
     if (x$val == "") {
       roxy_tag_warning(x, "requires a value")
     } else if (required && !str_detect(x$val, "[[:space:]]+")) {
@@ -136,7 +143,7 @@ tag_two_part <- function(first, second, required = TRUE) {
 
       x$val <- list(
         pieces[, 1],
-        trim_docstring(pieces[, 2])
+        trim_docstring(full_markdown(pieces[, 2]))
       )
       names(x$val) <- c(first, second)
       x
@@ -240,4 +247,3 @@ tag_markdown_restricted <- function(x) {
   x$val <- restricted_markdown(x$val)
   tag_value(x)
 }
-

--- a/tests/testthat/test-rd-markdown.R
+++ b/tests/testthat/test-rd-markdown.R
@@ -385,3 +385,27 @@ test_that("Escaping is kept", {
     foo <- function() {}")[[1]]
   expect_equal(get_tag(out1, "description"), get_tag(out2, "description"))
 })
+
+test_that("Do not pick up `` in arguments \\item #519", {
+
+  out1 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' Description.
+    #'
+    #' @param `_arg1` should not be code. But `this should`.
+    #' @param `_arg2` should not be code, either. `But this.`
+    #'
+    #' @md
+    foo <- function(`_arg1`, `_arg2`) {}")[[1]]
+  out2 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' Description.
+    #'
+    #' @param `_arg1` should not be code. But \\code{this should}.
+    #' @param `_arg2` should not be code, either. \\code{But this.}
+    #'
+    foo <- function(`_arg1`, `_arg2`) {}")[[1]]
+  expect_equal(get_tag(out1, "description"), get_tag(out2, "description"))
+})


### PR DESCRIPTION
Because that is typically just a name, and it parsing it
causes problems in some rare cases, see #519.
This commit closes #519.