### PR TITLE
Export objects via name vector

### DIFF
--- a/R/namespace.R
+++ b/R/namespace.R
@@ -105,7 +105,10 @@ ns_S3method          <- function(tag, block) {
 }
 ns_exportClass       <- function(tag, block) export_class(tag)
 ns_exportMethod      <- function(tag, block) export_s4_method(tag)
-ns_exportNames       <- function(tag, block) fun_args("export", tag)
+ns_exportNames       <- function(tag, block) {
+  nms <- eval(parse(text = tag))
+  fun_args("export", nms)
+}
 ns_exportPattern     <- function(tag, block) one_per_line("exportPattern", tag)
 ns_import            <- function(tag, block) one_per_line("import", tag)
 ns_importFrom        <- function(tag, block) repeat_first("importFrom", tag)

--- a/R/namespace.R
+++ b/R/namespace.R
@@ -1,6 +1,6 @@
-ns_tags <- c('export', 'exportClass', 'exportMethod', 'exportPattern',
-  'rawNamespace', 'S3method', 'import', 'importFrom', 'importClassesFrom',
-  'importMethodsFrom', 'useDynLib')
+ns_tags <- c('export', 'exportClass', 'exportMethod', 'exportNames',
+  'exportPattern', 'rawNamespace', 'S3method', 'import', 'importFrom',
+  'importClassesFrom', 'importMethodsFrom', 'useDynLib')
 
 #' Roclet: make NAMESPACE.
 #'
@@ -30,6 +30,7 @@ roclet_tags.roclet_namespace <- function(x) {
     export = tag_words_line,
     exportClass = tag_words(1),
     exportMethod = tag_words(1),
+    exportNames = tag_words(1),
     exportPattern = tag_words(1),
     import = tag_words(1),
     importClassesFrom = tag_words(2),
@@ -104,6 +105,7 @@ ns_S3method          <- function(tag, block) {
 }
 ns_exportClass       <- function(tag, block) export_class(tag)
 ns_exportMethod      <- function(tag, block) export_s4_method(tag)
+ns_exportNames       <- function(tag, block) fun_args("export", tag)
 ns_exportPattern     <- function(tag, block) one_per_line("exportPattern", tag)
 ns_import            <- function(tag, block) one_per_line("import", tag)
 ns_importFrom        <- function(tag, block) repeat_first("importFrom", tag)
@@ -123,7 +125,7 @@ ns_useDynLib         <- function(tag, block) {
     repeat_first("useDynLib", tag)
   }
 }
-ns_rawNamespace       <- function(tag, block) tag
+ns_rawNamespace      <- function(tag, block) tag
 
 # Functions used by both default_export and ns_* functions
 export           <- function(x) one_per_line("export", x)

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -189,6 +189,14 @@ test_that("empty NAMESPACE generates zero-length vector", {
   expect_equal(results, character())
 })
 
+test_that("exportNames parses object names", {
+  out <- roc_proc_text(namespace_roclet(), "
+    #' @exportNames c(letters[1:3], '_x', '%>%')
+    NULL")
+
+  expect_equal(out, "export(a,b,c,\"_x\",\"%>%\")")
+})
+
 
 # Raw ---------------------------------------------------------------------
 


### PR DESCRIPTION
Tag `@exportNames` allows one to export objects using a vector of names. Example:

``` r
fs <- lapply(1:10, function(a) {function(x) a + x})
names(fs) <- paste0("f_", 1:10)
for (nm in names(fs)) assign(nm, fs[[nm]])

#' @exportNames names(fs)
NULL
```

Such a tag is handy if one needs to export batches of closures, say (e.g., in a DSL).
