### PR TITLE
Inherit title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,9 +29,11 @@
     and will eventually be incorporated in to RStudio's autocomplete.
 
 * New `@inherit` generalises `@inheritParams`, and allows to you inherit
-  parameters, return, references, description, details, sections, and seealso. 
-  The default `@inherit my_fun` will inherit all, or you can select specific 
-  tags to inherit with `@inherit my_fun return params` (#384).
+  parameters, return, references, title, description, details, sections, and
+  seealso.  The default `@inherit my_fun` will inherit all, you can document
+  an object entirely by specifying only the `@inherit` tag.  Alternatively, 
+  you can select specific tags to inherit with `@inherit my_fun return params`
+  (#384).
 
 * New `@inheritSection fun title` allows you to inherit the contents of 
   a single section from another topic (#513).

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -5,6 +5,7 @@ topics_process_inherit <- function(topics, env) {
 
   topics$topo_apply(inherits("return"), inherit_field,
     roxy_name = "return", rd_name = "value")
+  topics$topo_apply(inherits("title"), inherit_field, "title")
   topics$topo_apply(inherits("description"), inherit_field, "description")
   topics$topo_apply(inherits("details"), inherit_field, "details")
   topics$topo_apply(inherits("seealso"), inherit_field, "seealso")

--- a/R/rd.R
+++ b/R/rd.R
@@ -71,9 +71,9 @@ roclet_process.roclet_rd <- function(x, parsed, base_path,
     rd <- block_to_rd(block, base_path, parsed$env, global_options)
     topics$add(rd)
   }
-  topics$drop_invalid()
   topics_process_family(topics)
   topics_process_inherit(topics, parsed$env)
+  topics$drop_invalid()
   topics_fix_params_order(topics)
 
   topics$topics

--- a/R/rd.R
+++ b/R/rd.R
@@ -174,7 +174,7 @@ needs_doc <- function(block) {
 
   key_tags <- c("description", "param", "return", "title", "example",
     "examples", "name", "rdname", "usage", "details", "introduction",
-    "describeIn")
+    "inherit", "describeIn")
 
   any(names(block) %in% key_tags)
 }

--- a/R/tag.R
+++ b/R/tag.R
@@ -78,7 +78,7 @@ tag_inherit <- function(x) {
     pieces <- str_split(str_trim(x$val), "\\s+")[[1]]
     fields <- pieces[-1]
 
-    all <- c("params", "return", "description", "details", "seealso",
+    all <- c("params", "return", "title", "description", "details", "seealso",
       "sections", "references")
     if (length(fields) == 0) {
       fields <- all

--- a/tests/testthat/test-Rd-inherit.R
+++ b/tests/testthat/test-Rd-inherit.R
@@ -22,7 +22,7 @@ test_that("no options gives default values", {
   expect_equal(
     block$inherit$fields,
     c(
-      "params", "return", "description", "details", "seealso", "sections",
+      "params", "return", "title", "description", "details", "seealso", "sections",
       "references"
     )
   )

--- a/tests/testthat/test-Rd-inherit.R
+++ b/tests/testthat/test-Rd-inherit.R
@@ -432,3 +432,28 @@ test_that("can inherit all from single function", {
   expect_match(params, "Arguments passed on to \\code{foo}", fixed = TRUE)
   expect_match(params, "\\item{x}{x}", fixed = TRUE)
 })
+
+# inherit everything ------------------------------------------------------
+
+test_that("can inherit all from single function", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Foo
+    #'
+    #' Description
+    #'
+    #' Details
+    #'
+    #' @param x x
+    #' @param y y
+    foo <- function(x, y) {}
+
+    #' @inherit foo
+    bar <- function(x, y) {}
+  ")[[2]]
+
+  params <- out$get_field("param")$values
+  expect_named(params, c("x", "y"))
+  expect_equal(out$get_field("title")$values, "Foo")
+  expect_equal(out$get_field("description")$values, "Description")
+  expect_equal(out$get_field("details")$values, "Details")
+})


### PR DESCRIPTION
This enables inheriting the title of a documentation entry, so that an `@inherit foo` is sufficient to document an object. I'm thinking about using it for RSQLite (to inherit method description from DBI), not sure yet if this is the right approach.