### PR TITLE
MD: comment that links to operators fail, closes #550

### DIFF
--- a/vignettes/markdown.Rmd
+++ b/vignettes/markdown.Rmd
@@ -202,3 +202,7 @@ The Commonmark parser does not require an empty line before lists, and this migh
 #' You can see more about this topic in the book cited below, on page
 #' 42. Clearly, the numbered list that starts here is not intentional.
 ```
+
+## Links to operators
+
+Links to operators or objects that contain special characters, do not work currently. E.g. to link to the `%>%` operator in the `magrittr` package, instead of `[magrittr::%>%]`, you will need to use the `Rd` notation: `\code{\link[magrittr]{\%>\%}}`.

--- a/vignettes/markdown.html
+++ b/vignettes/markdown.html
@@ -1,202 +1,226 @@
----
-title: "Write R Documentation in Markdown"
-author: "Gábor Csárdi"
-date: "2016-12-31"
-output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Write R Documentation in Markdown}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
----
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<meta name="author" content="Gábor Csárdi" />
+
+<meta name="date" content="2017-01-03" />
+
+<title>Write R Documentation in Markdown</title>
 
 
 
-# Introduction
+<style type="text/css">code{white-space: pre;}</style>
+<style type="text/css">
+div.sourceCode { overflow-x: auto; }
+table.sourceCode, tr.sourceCode, td.lineNumbers, td.sourceCode {
+  margin: 0; padding: 0; vertical-align: baseline; border: none; }
+table.sourceCode { width: 100%; line-height: 100%; }
+td.lineNumbers { text-align: right; padding-right: 4px; padding-left: 4px; color: #aaaaaa; border-right: 1px solid #aaaaaa; }
+td.sourceCode { padding-left: 5px; }
+code > span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code > span.dt { color: #902000; } /* DataType */
+code > span.dv { color: #40a070; } /* DecVal */
+code > span.bn { color: #40a070; } /* BaseN */
+code > span.fl { color: #40a070; } /* Float */
+code > span.ch { color: #4070a0; } /* Char */
+code > span.st { color: #4070a0; } /* String */
+code > span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code > span.ot { color: #007020; } /* Other */
+code > span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code > span.fu { color: #06287e; } /* Function */
+code > span.er { color: #ff0000; font-weight: bold; } /* Error */
+code > span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+code > span.cn { color: #880000; } /* Constant */
+code > span.sc { color: #4070a0; } /* SpecialChar */
+code > span.vs { color: #4070a0; } /* VerbatimString */
+code > span.ss { color: #bb6688; } /* SpecialString */
+code > span.im { } /* Import */
+code > span.va { color: #19177c; } /* Variable */
+code > span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code > span.op { color: #666666; } /* Operator */
+code > span.bu { } /* BuiltIn */
+code > span.ex { } /* Extension */
+code > span.pp { color: #bc7a00; } /* Preprocessor */
+code > span.at { color: #7d9029; } /* Attribute */
+code > span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code > span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code > span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+</style>
 
-Starting from version 6.0.0, roxygen supports markdown markup within most roxygen tags. Roxygen uses the `commonmark` package, which is based on the CommonMark Reference Implementation to parse these tags. See http://commonmark.org/help/ for more about the parser and the markdown language it supports.
 
-# Turning on markdown support
 
-There are two ways to turn on markdown support for a package: globally, at the package level, and locally at the block level.
+<link href="data:text/css;charset=utf-8,body%20%7B%0Abackground%2Dcolor%3A%20%23fff%3B%0Amargin%3A%201em%20auto%3B%0Amax%2Dwidth%3A%20700px%3B%0Aoverflow%3A%20visible%3B%0Apadding%2Dleft%3A%202em%3B%0Apadding%2Dright%3A%202em%3B%0Afont%2Dfamily%3A%20%22Open%20Sans%22%2C%20%22Helvetica%20Neue%22%2C%20Helvetica%2C%20Arial%2C%20sans%2Dserif%3B%0Afont%2Dsize%3A%2014px%3B%0Aline%2Dheight%3A%201%2E35%3B%0A%7D%0A%23header%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0A%23TOC%20%7B%0Aclear%3A%20both%3B%0Amargin%3A%200%200%2010px%2010px%3B%0Apadding%3A%204px%3B%0Awidth%3A%20400px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Aborder%2Dradius%3A%205px%3B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Afont%2Dsize%3A%2013px%3B%0Aline%2Dheight%3A%201%2E3%3B%0A%7D%0A%23TOC%20%2Etoctitle%20%7B%0Afont%2Dweight%3A%20bold%3B%0Afont%2Dsize%3A%2015px%3B%0Amargin%2Dleft%3A%205px%3B%0A%7D%0A%23TOC%20ul%20%7B%0Apadding%2Dleft%3A%2040px%3B%0Amargin%2Dleft%3A%20%2D1%2E5em%3B%0Amargin%2Dtop%3A%205px%3B%0Amargin%2Dbottom%3A%205px%3B%0A%7D%0A%23TOC%20ul%20ul%20%7B%0Amargin%2Dleft%3A%20%2D2em%3B%0A%7D%0A%23TOC%20li%20%7B%0Aline%2Dheight%3A%2016px%3B%0A%7D%0Atable%20%7B%0Amargin%3A%201em%20auto%3B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dcolor%3A%20%23DDDDDD%3B%0Aborder%2Dstyle%3A%20outset%3B%0Aborder%2Dcollapse%3A%20collapse%3B%0A%7D%0Atable%20th%20%7B%0Aborder%2Dwidth%3A%202px%3B%0Apadding%3A%205px%3B%0Aborder%2Dstyle%3A%20inset%3B%0A%7D%0Atable%20td%20%7B%0Aborder%2Dwidth%3A%201px%3B%0Aborder%2Dstyle%3A%20inset%3B%0Aline%2Dheight%3A%2018px%3B%0Apadding%3A%205px%205px%3B%0A%7D%0Atable%2C%20table%20th%2C%20table%20td%20%7B%0Aborder%2Dleft%2Dstyle%3A%20none%3B%0Aborder%2Dright%2Dstyle%3A%20none%3B%0A%7D%0Atable%20thead%2C%20table%20tr%2Eeven%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Ap%20%7B%0Amargin%3A%200%2E5em%200%3B%0A%7D%0Ablockquote%20%7B%0Abackground%2Dcolor%3A%20%23f6f6f6%3B%0Apadding%3A%200%2E25em%200%2E75em%3B%0A%7D%0Ahr%20%7B%0Aborder%2Dstyle%3A%20solid%3B%0Aborder%3A%20none%3B%0Aborder%2Dtop%3A%201px%20solid%20%23777%3B%0Amargin%3A%2028px%200%3B%0A%7D%0Adl%20%7B%0Amargin%2Dleft%3A%200%3B%0A%7D%0Adl%20dd%20%7B%0Amargin%2Dbottom%3A%2013px%3B%0Amargin%2Dleft%3A%2013px%3B%0A%7D%0Adl%20dt%20%7B%0Afont%2Dweight%3A%20bold%3B%0A%7D%0Aul%20%7B%0Amargin%2Dtop%3A%200%3B%0A%7D%0Aul%20li%20%7B%0Alist%2Dstyle%3A%20circle%20outside%3B%0A%7D%0Aul%20ul%20%7B%0Amargin%2Dbottom%3A%200%3B%0A%7D%0Apre%2C%20code%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0Aborder%2Dradius%3A%203px%3B%0Acolor%3A%20%23333%3B%0Awhite%2Dspace%3A%20pre%2Dwrap%3B%20%0A%7D%0Apre%20%7B%0Aborder%2Dradius%3A%203px%3B%0Amargin%3A%205px%200px%2010px%200px%3B%0Apadding%3A%2010px%3B%0A%7D%0Apre%3Anot%28%5Bclass%5D%29%20%7B%0Abackground%2Dcolor%3A%20%23f7f7f7%3B%0A%7D%0Acode%20%7B%0Afont%2Dfamily%3A%20Consolas%2C%20Monaco%2C%20%27Courier%20New%27%2C%20monospace%3B%0Afont%2Dsize%3A%2085%25%3B%0A%7D%0Ap%20%3E%20code%2C%20li%20%3E%20code%20%7B%0Apadding%3A%202px%200px%3B%0A%7D%0Adiv%2Efigure%20%7B%0Atext%2Dalign%3A%20center%3B%0A%7D%0Aimg%20%7B%0Abackground%2Dcolor%3A%20%23FFFFFF%3B%0Apadding%3A%202px%3B%0Aborder%3A%201px%20solid%20%23DDDDDD%3B%0Aborder%2Dradius%3A%203px%3B%0Aborder%3A%201px%20solid%20%23CCCCCC%3B%0Amargin%3A%200%205px%3B%0A%7D%0Ah1%20%7B%0Amargin%2Dtop%3A%200%3B%0Afont%2Dsize%3A%2035px%3B%0Aline%2Dheight%3A%2040px%3B%0A%7D%0Ah2%20%7B%0Aborder%2Dbottom%3A%204px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Apadding%2Dbottom%3A%202px%3B%0Afont%2Dsize%3A%20145%25%3B%0A%7D%0Ah3%20%7B%0Aborder%2Dbottom%3A%202px%20solid%20%23f7f7f7%3B%0Apadding%2Dtop%3A%2010px%3B%0Afont%2Dsize%3A%20120%25%3B%0A%7D%0Ah4%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23f7f7f7%3B%0Amargin%2Dleft%3A%208px%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Ah5%2C%20h6%20%7B%0Aborder%2Dbottom%3A%201px%20solid%20%23ccc%3B%0Afont%2Dsize%3A%20105%25%3B%0A%7D%0Aa%20%7B%0Acolor%3A%20%230033dd%3B%0Atext%2Ddecoration%3A%20none%3B%0A%7D%0Aa%3Ahover%20%7B%0Acolor%3A%20%236666ff%3B%20%7D%0Aa%3Avisited%20%7B%0Acolor%3A%20%23800080%3B%20%7D%0Aa%3Avisited%3Ahover%20%7B%0Acolor%3A%20%23BB00BB%3B%20%7D%0Aa%5Bhref%5E%3D%22http%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0Aa%5Bhref%5E%3D%22https%3A%22%5D%20%7B%0Atext%2Ddecoration%3A%20underline%3B%20%7D%0A%0Acode%20%3E%20span%2Ekw%20%7B%20color%3A%20%23555%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Edt%20%7B%20color%3A%20%23902000%3B%20%7D%20%0Acode%20%3E%20span%2Edv%20%7B%20color%3A%20%2340a070%3B%20%7D%20%0Acode%20%3E%20span%2Ebn%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Efl%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Ech%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Est%20%7B%20color%3A%20%23d14%3B%20%7D%20%0Acode%20%3E%20span%2Eco%20%7B%20color%3A%20%23888888%3B%20font%2Dstyle%3A%20italic%3B%20%7D%20%0Acode%20%3E%20span%2Eot%20%7B%20color%3A%20%23007020%3B%20%7D%20%0Acode%20%3E%20span%2Eal%20%7B%20color%3A%20%23ff0000%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%0Acode%20%3E%20span%2Efu%20%7B%20color%3A%20%23900%3B%20font%2Dweight%3A%20bold%3B%20%7D%20%20code%20%3E%20span%2Eer%20%7B%20color%3A%20%23a61717%3B%20background%2Dcolor%3A%20%23e3d2d2%3B%20%7D%20%0A" rel="stylesheet" type="text/css" />
 
-To turn on markdown for the whole package, insert this entry into the `DESCRIPTION` file of the package:
-```
-Roxygen: list(markdown = TRUE)
-```
-The position of the entry in the file does not matter. After this, all Roxygen documentation will be parsed as markdown.
+</head>
 
-Alternatively, you can use the `@md` tag to turn on markdown support for a single documentation chunk. This is a good option to write any new documentation for existing packages in markdown.
+<body>
 
-There is also a new `@noMd` tag. Use this if you turned on markdown parsing globally, but need to avoid it for a single chunk. This tag is handy if the markdown parser interferes with more complex Rd syntax.
 
-Here is an example roxygen chunk that uses markdown.
 
-```r
-#' Use roxygen to document a package.
-#'
-#' This function is a wrapper for the [roxygen2::roxygenize()] function from
-#' the `roxygen2` package. See the documentation and vignettes of
-#' that package to learn how to use roxygen.
-#'
-#' @param pkg package description, can be path or package name.  See
-#'   [as.package()] for more information
-#' @param clean,reload Deprecated.
-#' @inheritParams roxygen2::roxygenise
-#' @seealso [roxygen2::roxygenize()], `browseVignettes("roxygen2")`
-#' @export
-#' @md
-```
 
-# Syntax
+<h1 class="title toc-ignore">Write R Documentation in Markdown</h1>
+<h4 class="author"><em>Gábor Csárdi</em></h4>
+<h4 class="date"><em>2017-01-03</em></h4>
 
-## Emphasis
 
-*Emphasis* and **strong** (bold) text are supported. For emphasis, put the text between asterisks or underline characters. For strong text, use two asterisks at both sides.
 
-```r
-#' See `::is_falsy` for the definition of what is _falsy_
-#' and what is _truthy_.
-```
+<div id="introduction" class="section level1">
+<h1>Introduction</h1>
+<p>Starting from version 6.0.0, roxygen supports markdown markup within most roxygen tags. Roxygen uses the <code>commonmark</code> package, which is based on the CommonMark Reference Implementation to parse these tags. See <a href="http://commonmark.org/help/" class="uri">http://commonmark.org/help/</a> for more about the parser and the markdown language it supports.</p>
+</div>
+<div id="turning-on-markdown-support" class="section level1">
+<h1>Turning on markdown support</h1>
+<p>There are two ways to turn on markdown support for a package: globally, at the package level, and locally at the block level.</p>
+<p>To turn on markdown for the whole package, insert this entry into the <code>DESCRIPTION</code> file of the package:</p>
+<pre><code>Roxygen: list(markdown = TRUE)</code></pre>
+<p>The position of the entry in the file does not matter. After this, all Roxygen documentation will be parsed as markdown.</p>
+<p>Alternatively, you can use the <code>@md</code> tag to turn on markdown support for a single documentation chunk. This is a good option to write any new documentation for existing packages in markdown.</p>
+<p>There is also a new <code>@noMd</code> tag. Use this if you turned on markdown parsing globally, but need to avoid it for a single chunk. This tag is handy if the markdown parser interferes with more complex Rd syntax.</p>
+<p>Here is an example roxygen chunk that uses markdown.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' Use roxygen to document a package.</span>
+<span class="co">#'</span>
+<span class="co">#' This function is a wrapper for the [roxygen2::roxygenize()] function from</span>
+<span class="co">#' the `roxygen2` package. See the documentation and vignettes of</span>
+<span class="co">#' that package to learn how to use roxygen.</span>
+<span class="co">#'</span>
+<span class="co">#' @param pkg package description, can be path or package name.  See</span>
+<span class="co">#'   [as.package()] for more information</span>
+<span class="co">#' @param clean,reload Deprecated.</span>
+<span class="co">#' @inheritParams roxygen2::roxygenise</span>
+<span class="co">#' @seealso [roxygen2::roxygenize()], `browseVignettes(&quot;roxygen2&quot;)`</span>
+<span class="co">#' @export</span>
+<span class="co">#' @md</span></code></pre></div>
+</div>
+<div id="syntax" class="section level1">
+<h1>Syntax</h1>
+<div id="emphasis" class="section level2">
+<h2>Emphasis</h2>
+<p><em>Emphasis</em> and <strong>strong</strong> (bold) text are supported. For emphasis, put the text between asterisks or underline characters. For strong text, use two asterisks at both sides.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' See `::is_falsy` for the definition of what is _falsy_</span>
+<span class="co">#' and what is _truthy_.</span></code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' @references</span>
+<span class="co">#' Robert E Tarjan and Mihalis Yannakakis. (1984). Simple</span>
 
-```r
-#' @references
-#' Robert E Tarjan and Mihalis Yannakakis. (1984). Simple
+<span class="co">#' linear-time algorithms to test chordality of graphs, test acyclicity</span>
+<span class="co">#' of hypergraphs, and selectively reduce acyclic hypergraphs.</span>
+<span class="co">#' *SIAM Journal of Computation* **13**, 566-579.</span></code></pre></div>
+</div>
+<div id="code" class="section level2">
+<h2>Code</h2>
+<p>Inline code is supported via backticks.</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' @param ns Optionally, a named vector giving prefix-url pairs, as</span>
+<span class="co">#'   produced by `xml_ns`. If provided, all names will be explicitly</span>
+<span class="co">#'   qualified with the ns prefix, i.e. if the element `bar` is defined ...</span></code></pre></div>
+<p>For blocks of code, put your code between triple backticks:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' ```</span>
+<span class="co">#' pkg &lt;- make_packages(</span>
+<span class="co">#'   foo1 = { f &lt;- function() print(&quot;hello!&quot;) ; d &lt;- 1:10 },</span>
+<span class="co">#'   foo2 = { f &lt;- function() print(&quot;hello again!&quot;) ; d &lt;- 11:20 }</span>
+<span class="co">#' )</span>
+<span class="co">#' foo1::f()</span>
+<span class="co">#' foo2::f()</span>
+<span class="co">#' foo1::d</span>
+<span class="co">#' foo2::d</span>
+<span class="co">#' dispose_packages(pkg)</span>
+<span class="co">#' ```</span></code></pre></div>
+<p>Note that this is not needed in <code>@examples</code>, since its contents is formatted as R code, anyway.</p>
+</div>
+<div id="lists" class="section level2">
+<h2>Lists</h2>
+<p>Regular Markdown lists are recognized and converted to <code>\enumerate{}</code> or <code>\itemize{}</code> lists:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' There are two ways to use this function:</span>
+<span class="co">#' 1. If its first argument is not named, then it returns a function</span>
+<span class="co">#'    that can be used to color strings.</span>
+<span class="co">#' 1. If its first argument is named, then it also creates a</span>
+<span class="co">#'    style with the given name. This style can be used in</span>
+<span class="co">#'    `style`. One can still use the return value</span>
+<span class="co">#'    of the function, to create a style function.</span></code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' The style (the `...` argument) can be anything of the</span>
+<span class="co">#' following:</span>
+<span class="co">#' * An R color name, see `colors()`.</span>
+<span class="co">#' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means</span>
+<span class="co">#'   red. Transparency (alpha channel) values are ignored.</span>
+<span class="co">#' * A one-column matrix with three rows for the red, green</span>
+<span class="co">#'   and blue channels, as returned by [grDevices::col2rgb()]</span></code></pre></div>
+<p>Nested lists are also supported.</p>
+<p>Note that you do not have leave an empty line before the list. This is different from some markdown parsers.</p>
+</div>
+<div id="links" class="section level2">
+<h2>Links</h2>
+<p>Markdown hyperlinks work as usual:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' See more about the markdown markup at the</span>
+<span class="co">#' [Commonmark web site](http://commonmark.org/help)</span></code></pre></div>
+<p>URLs are also automatically converted to hyperlinks:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' The main R web site is at https://r-project.org.</span></code></pre></div>
+<p>Markdown notation can be used to create links to other manual pages. There are six kinds of links:</p>
+<ol style="list-style-type: decimal">
+<li>Link to another function in the same package: <code>[func()]</code>. These links will be typeset as code, and they are equavalent to <code>\code{\link[=func]{func()}</code>.</li>
+<li>Link to a (non-function) object, class, data set, etc. in the same same package: <code>[object]</code>. These links that <em>not</em> typeset as code, so if you want them as code, enclose them in backticks (inside the brackets).</li>
+<li>Link to a function from another package: <code>[pkg::func()]</code>. These links will be typeset as code.</li>
+<li>Link to a (non-function) object in another package: <code>[pkg::object]</code>. These links will not be typeset as code.</li>
+<li>Link to an object in the same package, with a different link text: <code>[link text][object]</code>. Here <code>object</code> can be a function, but the link text is not typeset as code.</li>
+<li>Link to an object in another package, with different link text: <code>[link text][pkg:object]</code>. This is not typeset as code.</li>
+</ol>
+<p>S3/S4 classes can be linked the same way:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' * [terms][terms.object] becomes \link[=terms.object]{terms}</span>
+<span class="co">#' * [abc][abc-class] becomes \link[=abc-class]{abc}</span></code></pre></div>
+<p>Or a shorthand notation can be used: <code>[abc-class]</code> is converted to <code>\linkS4class{abc}</code> and <code>[pkg::abc-class]</code> is converted to <code>\link[pkg:abc-class]{pkg::abc}</code>.</p>
+</div>
+<div id="images" class="section level2">
+<h2>Images</h2>
+<p>The parser recognizes the markdown notation for embedded images. The image files must in the <code>man/figures</code> directory:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' Here is an example plot:</span>
+<span class="co">#' ![](example-plot.jpg &quot;Example Plot Title&quot;)</span></code></pre></div>
+</div>
+</div>
+<div id="roxygen-and-rd-tags-not-parsed-as-markdown" class="section level1">
+<h1>Roxygen and Rd tags <em>not</em> parsed as markdown</h1>
+<p>Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: <code>@aliases</code>, <code>@backref</code>, <code>@docType</code>, <code>@encoding</code>, <code>@evalRd</code>, <code>@example</code>, <code>@examples</code>, <code>@family</code>, <code>@inheritParams</code>, <code>@keywords</code>, <code>@method</code> <code>@name</code>, <code>@md</code>, <code>@noMd</code>, <code>@noRd</code>, <code>@rdname</code>, <code>@rawRd</code>, <code>@usage</code>.</p>
+<p>When mixing <code>Rd</code> and markdown notation, most <code>Rd</code> tags may contain markdown markup, the ones that can <em>not</em> are: <code>\acronym</code>, <code>\code</code>, <code>\command</code>, <code>\CRANpkg</code>, <code>\deqn</code>, <code>\doi</code>, <code>\dontrun</code>, <code>\dontshow</code>, <code>\donttest</code>, <code>\email</code>, <code>\env</code>, <code>\eqn</code>, <code>\figure</code>, <code>\file</code>, <code>\if</code>, <code>\ifelse</code>, <code>\kbd</code>, <code>\link</code>, <code>\linkS4class</code>, <code>\method</code>, <code>\newcommand</code>, <code>\option</code>, <code>\out</code>, <code>\packageAuthor</code>, <code>\packageDescription</code>, <code>\packageDESCRIPTION</code>, <code>\packageIndices</code>, <code>\packageMaintainer</code>, <code>\packageTitle</code>, <code>\pkg</code>, <code>\PR</code>, <code>\preformatted</code>, <code>\renewcommand</code>, <code>\S3method</code>, <code>\S4method</code>, <code>\samp</code>, <code>\special</code>, <code>\testonly</code>, <code>\url</code>, <code>\var</code>, <code>\verb</code>.</p>
+</div>
+<div id="possible-problems" class="section level1">
+<h1>Possible problems</h1>
+<div id="mixing-markdown-and-rd-markup" class="section level2">
+<h2>Mixing markdown and <code>Rd</code> markup</h2>
+<p>Note that turning on markdown does <em>not</em> turn off the standard <code>Rd</code> syntax. We suggest that you use the regular <code>Rd</code> tags in a markdown roxygen chunk only if necessary. The two parsers do occasionally interact, and the markdown parser can pick up and reformat Rd syntax, causing an error, or currupted manuals.</p>
+</div>
+<div id="leading-whitespace" class="section level2">
+<h2>Leading whitespace</h2>
+<p>Leading whitespace is interpreted by the commonmark parser, whereas it is ignored by the <code>Rd</code> parser (except in <code>\preformatted{}</code>). Make sure that you only include leading whitespace intentionally, for example for nested lists.</p>
+</div>
+<div id="spurious-lists" class="section level2">
+<h2>Spurious lists</h2>
+<p>The Commonmark parser does not require an empty line before lists, and this might lead to unintended lists if a line starts with a number followed by a dot, or with an asterisk followed by whitespace:</p>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co">#' You can see more about this topic in the book cited below, on page</span>
+<span class="co">#' 42. Clearly, the numbered list that starts here is not intentional.</span></code></pre></div>
+</div>
+<div id="links-to-operators" class="section level2">
+<h2>Links to operators</h2>
+<p>Links to operators or objects that contain special characters, do not work currently. E.g. to link to the <code>%&gt;%</code> operator in the <code>magrittr</code> package, instead of <code>[magrittr::%&gt;%]</code>, you will need to use the <code>Rd</code> notation: <code>\code{\link[magrittr]{\%&gt;\%}}</code>.</p>
+</div>
+</div>
 
-#' linear-time algorithms to test chordality of graphs, test acyclicity
-#' of hypergraphs, and selectively reduce acyclic hypergraphs.
-#' *SIAM Journal of Computation* **13**, 566-579.
-```
 
-## Code
 
-Inline code is supported via backticks.
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
 
-```r
-#' @param ns Optionally, a named vector giving prefix-url pairs, as
-#'   produced by `xml_ns`. If provided, all names will be explicitly
-#'   qualified with the ns prefix, i.e. if the element `bar` is defined ...
-```
-
-For blocks of code, put your code between triple backticks:
-
-```r
-#' ```
-#' pkg <- make_packages(
-#'   foo1 = { f <- function() print("hello!") ; d <- 1:10 },
-#'   foo2 = { f <- function() print("hello again!") ; d <- 11:20 }
-#' )
-#' foo1::f()
-#' foo2::f()
-#' foo1::d
-#' foo2::d
-#' dispose_packages(pkg)
-#' ```
-```
-
-Note that this is not needed in `@examples`, since its contents is formatted as R code,
-anyway.
-
-## Lists
-
-Regular Markdown lists are recognized and converted to `\enumerate{}` or `\itemize{}` lists:
-
-```r
-#' There are two ways to use this function:
-#' 1. If its first argument is not named, then it returns a function
-#'    that can be used to color strings.
-#' 1. If its first argument is named, then it also creates a
-#'    style with the given name. This style can be used in
-#'    `style`. One can still use the return value
-#'    of the function, to create a style function.
-```
-
-```r
-#' The style (the `...` argument) can be anything of the
-#' following:
-#' * An R color name, see `colors()`.
-#' * A 6- or 8-digit hexa color string, e.g. `#ff0000` means
-#'   red. Transparency (alpha channel) values are ignored.
-#' * A one-column matrix with three rows for the red, green
-#'   and blue channels, as returned by [grDevices::col2rgb()]
-```
-
-Nested lists are also supported.
-
-Note that you do not have leave an empty line before the list. This is different from some markdown parsers.
-
-## Links
-
-Markdown hyperlinks work as usual:
-
-```r
-#' See more about the markdown markup at the
-#' [Commonmark web site](http://commonmark.org/help)
-```
-
-URLs are also automatically converted to hyperlinks:
-
-```r
-#' The main R web site is at https://r-project.org.
-```
-
-Markdown notation can be used to create links to other manual pages. There are six kinds of links:
-
-1. Link to another function in the same package: `[func()]`. These
-   links will be typeset as code, and they are equavalent to
-   `\code{\link[=func]{func()}`.
-2. Link to a (non-function) object, class, data set, etc. in the same
-   same package: `[object]`. These links that *not* typeset as code,
-   so if you want them as code, enclose them in backticks (inside the
-   brackets).
-3. Link to a function from another package: `[pkg::func()]`. These links
-   will be typeset as code.
-4. Link to a (non-function) object in another package: `[pkg::object]`.
-   These links will not be typeset as code.
-5. Link to an object in the same package, with a different link text:
-   `[link text][object]`. Here `object` can be a function, but the link
-   text is not typeset as code.
-6. Link to an object in another package, with different link text:
-   `[link text][pkg:object]`. This is not typeset as code.
-
-S3/S4 classes can be linked the same way:
-
-```r
-#' * [terms][terms.object] becomes \link[=terms.object]{terms}
-#' * [abc][abc-class] becomes \link[=abc-class]{abc}
-```
-
-Or a shorthand notation can be used: `[abc-class]` is converted to `\linkS4class{abc}` and `[pkg::abc-class]` is converted to `\link[pkg:abc-class]{pkg::abc}`.
-
-## Images
-
-The parser recognizes the markdown notation for embedded images. The image files must in the  `man/figures` directory:
-
-```r
-#' Here is an example plot:
-#' ![](example-plot.jpg "Example Plot Title")
-```
-
-# Roxygen and Rd tags *not* parsed as markdown
-
-Some of the roxygen tags are not parsed as markdown. Most of these are unlikely to contain text that needs markup, so this is not an important restriction. Tags without markdown support: `@aliases`, `@backref`, `@docType`, `@encoding`, `@evalRd`, `@example`, `@examples`, `@family`, `@inheritParams`, `@keywords`, `@method` `@name`, `@md`, `@noMd`, `@noRd`, `@rdname`, `@rawRd`, `@usage`.
-
-When mixing `Rd` and markdown notation, most `Rd` tags may contain markdown markup, the ones that can *not* are: `\acronym`, `\code`, `\command`, `\CRANpkg`, `\deqn`, `\doi`, `\dontrun`, `\dontshow`, `\donttest`, `\email`, `\env`, `\eqn`, `\figure`, `\file`, `\if`, `\ifelse`, `\kbd`, `\link`, `\linkS4class`, `\method`, `\newcommand`, `\option`, `\out`, `\packageAuthor`, `\packageDescription`, `\packageDESCRIPTION`, `\packageIndices`, `\packageMaintainer`, `\packageTitle`, `\pkg`, `\PR`, `\preformatted`, `\renewcommand`, `\S3method`, `\S4method`, `\samp`, `\special`, `\testonly`, `\url`, `\var`, `\verb`.
-
-# Possible problems
-
-## Mixing markdown and `Rd` markup
-
-Note that turning on markdown does *not* turn off the standard `Rd` syntax. We suggest that you use the regular `Rd` tags in a markdown roxygen chunk only if necessary. The two parsers do occasionally interact, and the markdown parser can pick up and reformat Rd syntax, causing an error, or currupted manuals.
-
-## Leading whitespace
-
-Leading whitespace is interpreted by the commonmark parser, whereas it is ignored by the `Rd` parser (except in `\preformatted{}`). Make sure that you only include leading whitespace intentionally, for example for nested lists.
-
-## Spurious lists
-
-The Commonmark parser does not require an empty line before lists, and this might lead to unintended lists if a line starts with a number followed by a dot, or with an asterisk followed by whitespace:
-
-```r
-#' You can see more about this topic in the book cited below, on page
-#' 42. Clearly, the numbered list that starts here is not intentional.
-```
+</body>
+</html>

--- a/vignettes/markdown.md
+++ b/vignettes/markdown.md
@@ -1,7 +1,7 @@
 ---
 title: "Write R Documentation in Markdown"
 author: "Gábor Csárdi"
-date: "2016-12-31"
+date: "2017-01-03"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Write R Documentation in Markdown}
@@ -200,3 +200,7 @@ The Commonmark parser does not require an empty line before lists, and this migh
 #' You can see more about this topic in the book cited below, on page
 #' 42. Clearly, the numbered list that starts here is not intentional.
 ```
+
+## Links to operators
+
+Links to operators or objects that contain special characters, do not work currently. E.g. to link to the `%>%` operator in the `magrittr` package, instead of `[magrittr::%>%]`, you will need to use the `Rd` notation: `\code{\link[magrittr]{\%>\%}}`.


### PR DESCRIPTION
I also fixed the markdown.html file, that I messed up last time. 

(Btw. is there an easy way to build all files from the `Rmd` vignette?)