### PR TITLE
fixed usage section for infix functions containing <-

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -106,6 +106,9 @@
 * Roxygen now parses nonASCII documentation correctly (as long as UTF-8 
   encoded or specified Encoding in DESCRIPTION) (#532, @shrektan),
   and ignores files listed in `.Rbuildignore` (#446, @fmichonneau).
+  
+* Automatically generating a usage section for an infix function containing "<-"
+  no longer removes "<-" from the function name (#554).
 
 ## Extending roxygen2
 

--- a/R/object-usage.R
+++ b/R/object-usage.R
@@ -50,7 +50,7 @@ object_usage.rcclass <- function(x) NULL
 
 function_usage <- function(name, formals, format_name = identity) {
   arglist <- args_string(usage_args(formals))
-  if (is_replacement_fun(name)) {
+  if (is_replacement_fun(name) && !is_infix_fun(name)) {
     name <- str_replace(name, fixed("<-"), "")
     formals$value <- NULL
 

--- a/tests/testthat/test-rd-usage.R
+++ b/tests/testthat/test-rd-usage.R
@@ -33,6 +33,14 @@ test_that("default usage correct for infix functions", {
   expect_equal(get_tag(out, "usage")$values, rd("a \\%.\\% b"))
 })
 
+test_that("default usage correct of infix functions containing \"<-\"", {
+  out <- roc_proc_text(rd_roclet(), "
+    #' Infix fun containing <-
+    '%<-%' <- function(a, b) 1")[[1]]
+
+  expect_equal(get_tag(out, "usage")$values, rd("a \\%<-\\% b"))
+})
+
 test_that("default usage correct for S3 methods", {
   out <- roc_proc_text(rd_roclet(), "
     #' Regular


### PR DESCRIPTION
A small change to the cases of `function_usage` in R/object-usage.R. Infix functions containing "<-" are no longer caught by the first if block. 

Added a test for infix functions containing "<-". 
