### PR TITLE
Imports R6 (>= 2.1.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     digest,
     methods,
     Rcpp (>= 0.11.0),
-    R6,
+    R6 (>= 2.1.2),
     desc,
     commonmark,
     xml2,


### PR DESCRIPTION
This is in response to klutometis/roxygen#600. 

I'm suggesting this merge into the master branch because it seems like a bugfix.

I'm suggesting that the R6 version is at least 2.1.2 because that is the lowest version for R6 that passed my (rudimentary) checks in a MWE. Again, see the issue ticket I link to above.