### PR TITLE
Support non-package code

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -29,14 +29,12 @@ parse_package <- function(base_path, load_code, registry, global_options = list(
 #' @return A list of roxygen2 blocks.
 #' @export
 #' @keywords internal
-parse_code <- function(
-  file, text = NULL,
-  env,
-  registry = default_tags(),
-  wrap = FALSE,
-  markdown = markdown_global_default,
-  file_encoding = "UTF-8"
-) {
+parse_code <- function(file, text = NULL,
+                       env,
+                       registry = default_tags(),
+                       wrap = FALSE,
+                       markdown = markdown_global_default,
+                       file_encoding = "UTF-8") {
   if (missing(file) && !is.null(text)) {
     file <- tempfile()
     writeLines(text, file)

--- a/R/parse.R
+++ b/R/parse.R
@@ -10,6 +10,38 @@ parse_package <- function(base_path, load_code, registry, global_options = list(
   list(env = env, blocks = blocks)
 }
 
+#' Parse roxygen2 comments in a piece of code.
+#'
+#' [parse_code()] takes a file or character vector, and an environment with R
+#' values, and parses the roxygen2 comments found in it.
+#'
+#' @param file Path of the file to process.
+#' @param env An environment containing the result of parsing and evaluating
+#'   the file.
+#' @param registry A roclet tag registry.
+#' @param wrap Logical; should roxygen2 output be wrapped? `FALSE` by default.
+#' @param markdown Logical value indicating whether to parse Markdown tags.
+#'   This can be overridden locally by the tags '@rd` and `@NoRd` inside a
+#'   Roxygen comment.
+#' @param file_encoding The file encoding. Default: `"UTF-8"`.
+#' @param text Instead of specifying `file`, users can also specify a character
+#' vector `text`, containing the R code.
+#' @return A list of roxygen2 blocks.
+#' @export
+parse_code <- function(file, env, registry = default_tags(), wrap = FALSE,
+                       markdown = markdown_global_default,
+                       file_encoding = "UTF-8", text) {
+  if (missing(file) && ! missing(text)) {
+    file <- tempfile()
+    writeLines(text, file)
+    on.exit(unlink(file))
+  }
+
+  options <- list(wrap = wrap, markdown = markdown)
+  parse_blocks(file, env, registry = registry, global_options = options,
+               fileEncoding = file_encoding)
+}
+
 parse_text <- function(text, registry = default_tags(), global_options = list()) {
   file <- tempfile()
   writeLines(text, file)

--- a/R/parse.R
+++ b/R/parse.R
@@ -16,6 +16,8 @@ parse_package <- function(base_path, load_code, registry, global_options = list(
 #' values, and parses the roxygen2 comments found in it.
 #'
 #' @param file Path of the file to process.
+#' @param text Instead of specifying `file`, users can also specify a character
+#'   vector `text`, containing the R code.
 #' @param env An environment containing the result of parsing and evaluating
 #'   the file.
 #' @param registry A roclet tag registry.
@@ -24,22 +26,31 @@ parse_package <- function(base_path, load_code, registry, global_options = list(
 #'   This can be overridden locally by the tags '@rd` and `@NoRd` inside a
 #'   Roxygen comment.
 #' @param file_encoding The file encoding. Default: `"UTF-8"`.
-#' @param text Instead of specifying `file`, users can also specify a character
-#' vector `text`, containing the R code.
 #' @return A list of roxygen2 blocks.
 #' @export
-parse_code <- function(file, env, registry = default_tags(), wrap = FALSE,
-                       markdown = markdown_global_default,
-                       file_encoding = "UTF-8", text) {
-  if (missing(file) && ! missing(text)) {
+#' @keywords internal
+parse_code <- function(
+  file, text = NULL,
+  env,
+  registry = default_tags(),
+  wrap = FALSE,
+  markdown = markdown_global_default,
+  file_encoding = "UTF-8"
+) {
+  if (missing(file) && !is.null(text)) {
     file <- tempfile()
     writeLines(text, file)
     on.exit(unlink(file))
   }
 
   options <- list(wrap = wrap, markdown = markdown)
-  parse_blocks(file, env, registry = registry, global_options = options,
-               fileEncoding = file_encoding)
+  parse_blocks(
+    file,
+    env,
+    registry = registry,
+    global_options = options,
+    fileEncoding = file_encoding
+  )
 }
 
 parse_text <- function(text, registry = default_tags(), global_options = list()) {


### PR DESCRIPTION
As suggested by @hadley in #273, here’s a suggested API for trivially adding single-file parsing support for Roxygen2.

At the moment the proposed change is pretty minimal (but already sufficient for my purposes): it adds a single, exported function `parse_code` that takes a file or a piece of R code as text, along with an environment of parsed R expressions, and parses the Roxygen tags associated with these objects, to be returned to the user.

I could alternatively/additionally imagine providing a `roxigenize_file` function (as shown in branch [`single-file-support-roxygenize`](../compare/master...klmr:single-file-support-roxygenize?expand=1)).

I would greatly appreciate feedback to make this PR suitable for merging into Roxygen2.

Here’s why I think it’s useful:

* [I need it](https://github.com/klmr/modules/blob/44db137fbdb431bc0f75422dfc239db1e7214f2e/R/help.r#L2) for ‹[modules](/klmr/modules)› (see also the above-mentioned issue)
* [Others need it](https://cran.r-project.org/web/packages/document/index.html).

I appreciate that “this is currently outside the scope of roxygen” as Hadley said. However, I think it’s a worthwhile addition because:

1. It’s trivial to add and maintain (the current PR is a single function).
2. The alternative would be for me or somebody else to create an exact copy of about 90% of roxygen2, maintained as a separate code base and separate CRAN project.
3. It’s useful: the output of the function ([after applying roclets](https://github.com/klmr/modules/blob/44db137fbdb431bc0f75422dfc239db1e7214f2e/R/help.r#L13-L14), which are already part of the public API of roxygen2) can be fed to `tools::parse_Rd` and then to e.g. `tools::Rd2txt`, and displayed. In fact, [that’s what ‹modules› is doing](https://github.com/klmr/modules/blob/44db137fbdb431bc0f75422dfc239db1e7214f2e/R/display_help.r). If there’s demand, it would be trivial to refactor the “display help from Rd” functionality into a separate package.