### PR TITLE
Fixing a bug that broke parsing of R.methodsS3::setMethodS3 and R.oo:::setConstructorS3.

### DIFF
--- a/R/object-from-call.R
+++ b/R/object-from-call.R
@@ -142,13 +142,13 @@ parser_setMethodS3 <- function(call, env, block) {
   method <- as.character(call[[2]])
   class <- as.character(call[[3]])
   name <- paste(method, class, sep=".")
-  value <- standardise_obj(get(name, env), value, env, block)
+  value <- standardise_obj(name, get(name, env), env, block)
   object(value, name)
 }
 
 parser_setConstructorS3 <- function(call, env, block) {
   # R.oo::setConstructorS3(name, ...)
   name <- as.character(call[[2]])
-  value <- standardise_obj(get(name, env), value, env, block)
+  value <- standardise_obj(name, get(name, env), env, block)
   object(value, name)
 }


### PR DESCRIPTION
The fixed bug was introduced in code review of pull request #525 (the arguments to a call to standardise_obj were incorrectly changed). This also fixes issue [631](https://github.com/klutometis/roxygen/issues/631).