### PR TITLE
Allow more than one given name in Authors@R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,9 @@
 * You can now autogenerate package documentation even if you don't have 
   `Authors@R` (#606).
 
+* Multiple given and/or family names are now supported in the
+  `Authors@R` field of the DESCRIPTION file (#672, @sgibb).
+
 * If a package logo exists (`man/figures/logo.png`) it will be automatically
   included in generated package docs (#609).
 

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -39,7 +39,7 @@ author_desc <- function(x) {
   desc <- paste0(x$given, collapse=" ")
 
   if (!is.null(x$family)) {
-    desc <- paste0(desc, " ", x$family)
+    desc <- paste0(desc, " ", paste0(x$family, collapse = " "))
   }
 
   if (!is.null(x$email)) {

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -36,7 +36,7 @@ package_authors <- function(desc) {
 }
 
 author_desc <- function(x) {
-  desc <- paste0(x$given, collapse=" ")
+  desc <- paste0(x$given, collapse = " ")
 
   if (!is.null(x$family)) {
     desc <- paste0(desc, " ", paste0(x$family, collapse = " "))

--- a/R/object-package.R
+++ b/R/object-package.R
@@ -36,7 +36,7 @@ package_authors <- function(desc) {
 }
 
 author_desc <- function(x) {
-  desc <- x$given
+  desc <- paste0(x$given, collapse=" ")
 
   if (!is.null(x$family)) {
     desc <- paste0(desc, " ", x$family)

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -1,17 +1,18 @@
 context("Object: Package")
 
 test_that("author with more than one given/family name ", {
-  expect_equal(author_desc(
-                 person(
-                   given = c("First", "Second"),
-                   family = c("Family1", "Family2"),
-                   email = "first.second.family@email.tld"
-                 )
-               ),
-               paste(
-                 "First Second",
-                 "Family1 Family2",
-                 "\\email{first.second.family@email.tld}"
-               )
+  expect_equal(
+    author_desc(
+      person(
+        given = c("First", "Second"),
+        family = c("Family1", "Family2"),
+        email = "first.second.family@email.tld"
+      )
+    ),
+    paste(
+      "First Second",
+      "Family1 Family2",
+      "\\email{first.second.family@email.tld}"
+    )
   )
 })

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -1,0 +1,34 @@
+context("Object: Package")
+
+test_that("author with one given name ", {
+  expect_equal(author_desc(list(given="Given",
+                                family="Family",
+                                role=c("aut", "cre"),
+                                email="given.family@email.tld",
+                                comment=NULL)),
+               "Given Family \\email{given.family@email.tld}"
+  )
+})
+
+test_that("author with more than one given name ", {
+  expect_equal(author_desc(list(given=c("First", "Second"),
+                                family="Family",
+                                role=c("aut", "cre"),
+                                email="first.second.family@email.tld",
+                                comment=NULL)),
+               "First Second Family \\email{first.second.family@email.tld}"
+  )
+})
+
+test_that("Authors@R with more than one given name ", {
+  expect_equal(package_authors(list("Authors@R"=
+    paste0("c(person(\"Given\", \"Family\", role=c(\"aut\", \"cre\"), ",
+           "email=\"given.family@email.tld\"), ",
+           "person(c(\"First\", \"Second\"), \"Family\", role=\"aut\", ",
+           "email=\"first.second.family@email.tld\"))"))),
+    paste0("\\strong{Maintainer}: Given Family ",
+           "\\email{given.family@email.tld}\n\n",
+           "Authors:\n\\itemize{\n  \\item First Second Family ",
+           "\\email{first.second.family@email.tld}\n}\n")
+  )
+})

--- a/tests/testthat/test-object-package.R
+++ b/tests/testthat/test-object-package.R
@@ -1,34 +1,17 @@
 context("Object: Package")
 
-test_that("author with one given name ", {
-  expect_equal(author_desc(list(given="Given",
-                                family="Family",
-                                role=c("aut", "cre"),
-                                email="given.family@email.tld",
-                                comment=NULL)),
-               "Given Family \\email{given.family@email.tld}"
-  )
-})
-
-test_that("author with more than one given name ", {
-  expect_equal(author_desc(list(given=c("First", "Second"),
-                                family="Family",
-                                role=c("aut", "cre"),
-                                email="first.second.family@email.tld",
-                                comment=NULL)),
-               "First Second Family \\email{first.second.family@email.tld}"
-  )
-})
-
-test_that("Authors@R with more than one given name ", {
-  expect_equal(package_authors(list("Authors@R"=
-    paste0("c(person(\"Given\", \"Family\", role=c(\"aut\", \"cre\"), ",
-           "email=\"given.family@email.tld\"), ",
-           "person(c(\"First\", \"Second\"), \"Family\", role=\"aut\", ",
-           "email=\"first.second.family@email.tld\"))"))),
-    paste0("\\strong{Maintainer}: Given Family ",
-           "\\email{given.family@email.tld}\n\n",
-           "Authors:\n\\itemize{\n  \\item First Second Family ",
-           "\\email{first.second.family@email.tld}\n}\n")
+test_that("author with more than one given/family name ", {
+  expect_equal(author_desc(
+                 person(
+                   given = c("First", "Second"),
+                   family = c("Family1", "Family2"),
+                   email = "first.second.family@email.tld"
+                 )
+               ),
+               paste(
+                 "First Second",
+                 "Family1 Family2",
+                 "\\email{first.second.family@email.tld}"
+               )
   )
 })


### PR DESCRIPTION
The Authors@R field in the DESCRIPTION file uses the `person` class for
managing the authors. If a author has more than one given name
`roxygenise` failed with an error in `package_authors`:

    Error in vapply(unclass(authors), author_desc, character(1)) :
        values must be length 1,
    but FUN(X[[1]]) result is length 2

Example DESCRIPTION:

    Authors@R: c(person(given=c("First", "Second"), "Family", role="aut", 
                        email="first.second.family@email.tld"),
                 person("Given", "Family", role=c("aut", "cre"), email="given.family@email.tld"))


This commit concatenates all given names separated by a space to solve
this error, e.g. `"First Second Family \\email{first.second.family@email.tld}"`.

For most western cultures that should be fine. Unfortunately
I don't know anything about other naming schemes.