### PR TITLE
Added tags to wrap examples written in stand alone syntactically valid R scripts within the \dontrun, \dontshow, or \donttest environments.

### DIFF
--- a/R/rd.R
+++ b/R/rd.R
@@ -34,6 +34,9 @@ roclet_tags.roclet_rd <- function(x) {
     encoding = tag_value,
     evalRd = tag_code,
     example = tag_value,
+    exampleDontrun = tag_value,
+    exampleDontshow = tag_value,
+    exampleDonttest = tag_value,
     examples = tag_examples,
     family = tag_value,
     field = tag_name_description,
@@ -200,6 +203,7 @@ needs_doc <- function(block) {
   }
 
   key_tags <- c("description", "param", "return", "title", "example",
+    "exampleDontrun", "exampleDontshow", "exampleDonttest",
     "examples", "name", "rdname", "usage", "details", "introduction",
     "inherit", "describeIn")
 
@@ -358,6 +362,7 @@ topic_add_examples <- function(topic, block, base_path) {
     topic$add_simple_field("examples", example)
   }
 
+  # for example tag 
   paths <- str_trim(unlist(block_tags(block, "example")))
   paths <- file.path(base_path, paths)
 
@@ -379,6 +384,73 @@ topic_add_examples <- function(topic, block, base_path) {
 
     topic$add_simple_field("examples", examples)
   }
+
+  # for exampleDontrun tag 
+  paths <- str_trim(unlist(block_tags(block, "exampleDontrun")))
+  paths <- file.path(base_path, paths)
+
+  for (path in paths) {
+    nl <- str_count(path, "\n")
+    if (any(nl) > 0) {
+      block_warning(block, "@exampleDontrun spans multiple lines. Do you want @examples?")
+      next
+    }
+
+    if (!file.exists(path)) {
+      block_warning(block, "@exampleDontrun ", path, " doesn't exist")
+      next
+    }
+
+    code <- c("\\dontrun{", read_lines(path), "}")
+    examples <- escape_examples(code)
+
+    topic$add_simple_field("examples", examples)
+  }
+
+  # for exampleDontshow tag 
+  paths <- str_trim(unlist(block_tags(block, "exampleDontshow")))
+  paths <- file.path(base_path, paths)
+
+  for (path in paths) {
+    nl <- str_count(path, "\n")
+    if (any(nl) > 0) {
+      block_warning(block, "@exampleDontshow spans multiple lines. Do you want @examples?")
+      next
+    }
+
+    if (!file.exists(path)) {
+      block_warning(block, "@exampleDontshow ", path, " doesn't exist")
+      next
+    }
+
+    code <- c("\\dontshow{", read_lines(path), "}")
+    examples <- escape_examples(code)
+
+    topic$add_simple_field("examples", examples)
+  }
+
+  # for exampleDonttest tag 
+  paths <- str_trim(unlist(block_tags(block, "exampleDonttest")))
+  paths <- file.path(base_path, paths)
+
+  for (path in paths) {
+    nl <- str_count(path, "\n")
+    if (any(nl) > 0) {
+      block_warning(block, "@exampleDonttest spans multiple lines. Do you want @examples?")
+      next
+    }
+
+    if (!file.exists(path)) {
+      block_warning(block, "@exampleDonttest ", path, " doesn't exist")
+      next
+    }
+
+    code <- c("\\donttest{", read_lines(path), "}")
+    examples <- escape_examples(code)
+
+    topic$add_simple_field("examples", examples)
+  }
+
 }
 
 topic_add_eval_rd <- function(topic, block, env) {

--- a/vignettes/rd.Rmd
+++ b/vignettes/rd.Rmd
@@ -151,6 +151,24 @@ Functions are the mostly commonly documented objects. Most functions use three t
     put them in separate files and use `@example path/relative/to/packge/root`
     to insert them into the documentation.
 
+    If you have placed examples in separate files and need to wrap the example
+    inside of `\dontrun{}`, `\dontshow{}`, or `\donttest{}` then you can place
+    the command directly in the example file.  If you use the `@example` tag,
+    e.g., `@example path/relative/to/packge/root/dont-run.R`, you can add the
+    command directly in the file:
+
+```
+\dontrun{
+# some long running example
+}
+```
+    While this formating works well for roxygen to generate the man file, the
+    `dont-run.R` file can not be evaluated via `source()`.  To aliviate this
+    issue three additional example tags have been added: `@exampleDontrun`,
+    `@exampleDontshow`, and `@exampleDonttest`.  Using these tags in the same
+    way that the `@example` tag is used, allows R syntactically valid scripts to
+    be wrapped in the respected command in the manual file.
+
 *   `@return description` describes the output from the function. This is
     not always necessary, but is a good idea if you return different types
     of outputs depending on the input, or you're returning an S3, S4 or RC


### PR DESCRIPTION
This feature address klutometis/roxygen#359

As part of my development process I frequently like to place examples in stand alone files for incremental testing and eventual documentation.  As such, being able to `source` the file is extremely helpful.  When the `\dontrun`, `\dontshow`, or `\donttest` wrappers are needed and added to the stand alone file such that the documentation is correct when using the `@example` tag the file can no longer be `source`d.

My solution: add three new tags, `@exampleDontrun`, `@exampleDontshow`, and `@exampleDonttest`.  These tags work the same way that `@example` does but wraps the syntactically valid R scripts in the respective environment.

Additional note: this feature has been noted at least twice on SO,
* https://stackoverflow.com/questions/12038160/how-to-not-run-an-example-using-roxygen2
* https://stackoverflow.com/questions/31412724/roxygen2-how-to-not-run-example-file

