### PR TITLE
fix link target, mention additional link style

### DIFF
--- a/vignettes/formatting.Rmd
+++ b/vignettes/formatting.Rmd
@@ -33,9 +33,11 @@ To other documentation:
 
 * `\code{\link{function}}`: function in this package
 
-* `\code{\link[MASS]{stats}}`: function in another package
+* `\code{\link[MASS]{abbey}}`: function in another package
 
 * `\link[=dest]{name}`: link to dest, but show name
+
+* `\code{\link[MASS:abbey]{name}}`: link to function in another package, but show name.
 
 * `\linkS4class{abc}`: link to an S4 class
 


### PR DESCRIPTION
- fix the target of the inter-package link. `MASS::stats` does not exist, but `MASS::abbey` does.
- mention link style `\link[pkg:bar]{foo}`. This link style is documented at https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Cross_002dreferences. And it is the _only_ link style not described in this vignette, every other style is mentioned here.