### PR TITLE
Update DESCRIPTION: Dependence for stringr changed from 0.5 to 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
     R6 (>= 2.1.2),
     Rcpp (>= 0.11.0),
     stringi,
-    stringr (>= 0.5),
+    stringr (>= 1.0.0),
     utils,
     xml2
 Suggests: 


### PR DESCRIPTION
I had an issue related to this [issue](https://github.com/klutometis/roxygen/issues/627) and discovered that the dependence that was causing the problem was stringr. Thus, I have updated the DESCRIPTION file accordingly.

There was a change in the str_trim() function in the stringr package from version 0.6.2 to 1.0.0. The old version of str_trim() was causing problems with roxygenise().