### PR TITLE
Set width argument of wrapString() call to 75 for usage section

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,8 +55,13 @@
 
 ## Minor improvements and bug fixes
 
-* `person` now supports all [MARC Relator](http://www.loc.gov/marc/relators/relaterm.html)
-  role codes (#662, @publicus).
+* `topic_add_usage()` now outputs formatted "Usage" section with max
+  width of 80 characters thanks to a now more flexible `wrap_string()`
+  (@JoshOBrien, #719).
+	
+* `person()` now supports all
+  [MARC Relator](http://www.loc.gov/marc/relators/relaterm.html) role codes
+  (#662, @publicus).
 
 * Empty `.Rbuildignore` now handled correctly (#576).
 

--- a/R/rd.R
+++ b/R/rd.R
@@ -331,7 +331,7 @@ topic_add_keyword <- function(topic, block) {
 # Prefer explicit \code{@@usage} to a \code{@@formals} list.
 topic_add_usage <- function(topic, block) {
   if (is.null(block$usage)) {
-    usage <- wrap_string(object_usage(attr(block, "object")))
+    usage <- wrap_string(object_usage(attr(block, "object")), width = 75L)
   } else if (block$usage == "NULL") {
     usage <- NULL
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -157,7 +157,7 @@ read.description <- function(file) {
 
 
 wrap_string <- function(x, ...) UseMethod("wrap_string")
-wrap_string.NULL <- function(x) return(x)
+wrap_string.NULL <- function(x, width = NULL) return(x)
 wrap_string.default <- function(x, width = 80L) {
   y <- wrapString(x, width = as.integer(width))
   y <- gsub("\u{A0}", " ", y, useBytes = TRUE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -156,10 +156,10 @@ read.description <- function(file) {
 }
 
 
-wrap_string <- function(x) UseMethod("wrap_string")
+wrap_string <- function(x, ...) UseMethod("wrap_string")
 wrap_string.NULL <- function(x) return(x)
-wrap_string.default <- function(x) {
-  y <- wrapString(x)
+wrap_string.default <- function(x, width = 80L) {
+  y <- wrapString(x, width = as.integer(width))
   y <- gsub("\u{A0}", " ", y, useBytes = TRUE)
   Encoding(y) <- "UTF-8"
   class(y) <- class(x)


### PR DESCRIPTION
At present, it's set to 80. Given that a further 5 space indent is added to the Usage section in the process of compiling rendered help files from Rd files, this means that the section can have width up to 85. This causes unattractive/distracting wrap around of some lines in textual help output (i.e. that got by doing `help(., help_type="text")`) in devices whose default viewing window is 80 characters wide.

Not sure that my proposed solution is optimal, but it involves few enough lines of code that it should be easy to review.