### PR TITLE
#Always use UTF-8 encoding when parsing DESCRIPTION files

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -149,10 +149,10 @@ block_eval <- function(tag, block, env, tag_name) {
 
 # Parse DESCRIPTION into convenient format
 read.description <- function(file) {
-  dcf <- read.dcf(file, keep.white = "Authors@R")
+  dcf <- desc::desc(file = file)
 
-  dcf_list <- setNames(as.list(dcf[1, ]), colnames(dcf))
-  lapply(dcf_list, str_trim)
+  fields <- dcf$fields()
+  purrr::map(purrr::set_names(fields), ~ dcf$get_field(.x))
 }
 
 

--- a/tests/testthat/test-rd-package.R
+++ b/tests/testthat/test-rd-package.R
@@ -18,3 +18,7 @@ test_that("can create package documentation", {
   expect_equal(get_tag(out, "docType")$values, "package")
   expect_equal(get_tag(out, "details")$values, "Details.")
 })
+
+test_that("Can read UTF-8 DESCRIPTIONS", {
+  expect_equal(read.description("testNonASCII/DESCRIPTION")$Author, "Shr\U00EBktan <shrektan@126.com>")
+})

--- a/tests/testthat/testNonASCII/DESCRIPTION
+++ b/tests/testthat/testNonASCII/DESCRIPTION
@@ -2,7 +2,7 @@ Package: testNonASCII
 Title: Test no change to Collate when there are no @includes
 License: GPL-2
 Description:
-Author: Shrektan <shrektan@126.com>
-Maintainer: Shrektan <shrektan@126.com>
+Author: Shrëktan <shrektan@126.com>
+Maintainer: Shrëktan <shrektan@126.com>
 Encoding: UTF-8
 Version: 0.1


### PR DESCRIPTION
Fixes #727