### PR TITLE
Display name of help page from which section couldn't be inherited

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,9 @@
   problems and ensures that `devtools::document()` and `roxygenise()` always
   have exactly the same behaviour (#568, #595).
 
+* If an inherited section cannot be found, the warning contains the help
+  page from which that section was requested (#732, @krlmlr).
+
 ## Extension API
 
 * [API] Roxygen blocks now have an official structure as encoded in 

--- a/R/rd-inherit.R
+++ b/R/rd-inherit.R
@@ -166,7 +166,10 @@ inherit_section <- function(topic, topics) {
     selected <- new_section$title %in% titles[[i]]
 
     if (sum(selected) != 1) {
-      warning("Can't find section '", titles[[i]], "'", call. = FALSE)
+      warning(
+        "Can't find section '", titles[[i]], "' in ?",
+        sources[[i]], call. = FALSE
+      )
     }
 
     topic$add_field(


### PR DESCRIPTION
If an inherited section cannot be found, the warning contains the help  page from which that section was requested.