### PR TITLE
Skip devtools tests if unavailable.

### DIFF
--- a/tests/testthat/test-rd-data.R
+++ b/tests/testthat/test-rd-data.R
@@ -1,6 +1,8 @@
 context("Rd: data")
 
 test_that("can document eager data", {
+  skip_if_not_installed("devtools")
+
   test_pkg <- temp_copy_pkg('testEagerData')
   on.exit(unlink(test_pkg, recursive = TRUE))
 
@@ -9,6 +11,8 @@ test_that("can document eager data", {
 })
 
 test_that("can document lazy data", {
+  skip_if_not_installed("devtools")
+
   test_pkg <- temp_copy_pkg('testLazyData')
   on.exit(unlink(test_pkg, recursive = TRUE))
 


### PR DESCRIPTION
There's a (Suggests) dependency loop here. As there's only two uses here, it's pretty simple to add the skip for them in this package.