### PR TITLE
Preserve whitespace as single space in link-reference text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,7 +110,7 @@
     * Code in link text is now properly rendered as code (#620, @egnha).
 
     * Whitespace between words in link text is now preserved as single
-      space (#628, @egnha).
+      space (#628, #754, @egnha).
 
     * `%` in inline code (#640), code blocks (@nteetor, #699) and
       links (#724) is now automatically escaped.

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -232,9 +232,13 @@ ws_to_empty <- function(x) {
 ## xml_text(). So we preserve newlines as spaces.
 
 xml_href_text <- function(xml) {
-  cnts <- xml_contents(xml)
-  text <- xml_text(cnts)
-  text[xml_name(cnts) %in% c("linebreak", "softbreak")] <- " "
+  contents <- xml_contents(xml)
+  xml_text_preserve_ws(contents)
+}
+
+xml_text_preserve_ws <- function(contents) {
+  text <- xml_text(contents)
+  text[xml_name(contents) %in% c("linebreak", "softbreak")] <- " "
   text
 }
 
@@ -377,7 +381,7 @@ parse_link <- function(destination, contents) {
     )
 
   } else {
-    contents <- gsub("%", "\\\\%", xml2::xml_text(contents))
+    text <- gsub("%", "\\\\%", xml_text_preserve_ws(contents))
 
     list(
       paste0(
@@ -387,7 +391,7 @@ parse_link <- function(destination, contents) {
         obj,
         "]{"
       ),
-      contents,
+      text,
       "}",
       if (is_code) "}" else ""
     )

--- a/tests/testthat/test-rd-markdown-links.R
+++ b/tests/testthat/test-rd-markdown-links.R
@@ -202,6 +202,34 @@ test_that("short and sweet links work", {
   expect_equivalent_rd(out1, out2)
 })
 
+test_that("whitespace is preserved as space in link-reference text (#754)", {
+  out1 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' A [function link split
+    #' over lines][fun()].
+    #' An [object link split
+    #' over lines][obj].
+    #' A [namespace-referenced function link split
+    #' over lines][pkg::fun()].
+    #' A [namespace-referenced object link split
+    #' over lines][pkg::obj].
+    #'
+    #' @md
+    foo <- function() {}")[[1]]
+  out2 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' A \\link[=fun]{function link split over lines}.
+    #' An \\link[=obj]{object link split over lines}.
+    #' A \\link[pkg:fun]{namespace-referenced function link split over lines}.
+    #' A \\link[pkg:obj]{namespace-referenced object link split over lines}.
+    #'
+    #' @md
+    foo <- function() {}")[[1]]
+  expect_equivalent_rd(out1, out2)
+})
+
 test_that("a weird markdown link bug is fixed", {
 
   out1 <- roc_proc_text(roc, "


### PR DESCRIPTION
Fixes #754