### PR TITLE
Fix whitespace in more links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -110,7 +110,8 @@
     * Code in link text is now properly rendered as code (#620, @egnha).
 
     * Whitespace between words in link text is now preserved as single
-      space (#628, @egnha).
+      space for links of the form `[text][fcn]` and `[text](URL)`
+      (#628, #754, #760, @egnha and @jennybc).
 
     * `%` in inline code (#640), code blocks (@nteetor, #699) and
       links (#724) is now automatically escaped.

--- a/R/markdown.R
+++ b/R/markdown.R
@@ -209,7 +209,7 @@ markdown_tags <- list(
     } else if (dest == "" || dest == xml_text(xml)) {
       list("\\url{", xml_text(xml), "}")
     } else {
-      list("\\href{", dest, "}{", xml_href_text(xml), "}")
+      list("\\href{", dest, "}{", xml_link_text(contents), "}")
     }
   },
 
@@ -231,10 +231,9 @@ ws_to_empty <- function(x) {
 ## markdown_xml(), which then get interpreted as empty strings by
 ## xml_text(). So we preserve newlines as spaces.
 
-xml_href_text <- function(xml) {
-  cnts <- xml_contents(xml)
-  text <- xml_text(cnts)
-  text[xml_name(cnts) %in% c("linebreak", "softbreak")] <- " "
+xml_link_text <- function(xml_contents) {
+  text <- xml_text(xml_contents)
+  text[xml_name(xml_contents) %in% c("linebreak", "softbreak")] <- " "
   text
 }
 
@@ -377,7 +376,7 @@ parse_link <- function(destination, contents) {
     )
 
   } else {
-    contents <- gsub("%", "\\\\%", xml2::xml_text(contents))
+    contents <- gsub("%", "\\\\%", xml_link_text(contents))
 
     list(
       paste0(

--- a/tests/testthat/test-rd-markdown-links.R
+++ b/tests/testthat/test-rd-markdown-links.R
@@ -403,3 +403,37 @@ test_that("links to S4 classes are OK", {
   expect_equivalent_rd(out1, out2)
 
 })
+
+test_that("linebreak in 'text' of [text][foo] turns into single space", {
+
+  out1 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' Link
+    #' text [broken
+    #' across lines][fcn] preserve
+    #' whitespace, even when
+    #' [broken across
+    #' several
+    #' lines][fcn],
+    #' or with varying
+    #' [amounts \
+    #'   of  \
+    #' interspersed   \
+    #'   whitespace][fcn].
+    #' @md
+    foo <- function() {}")[[1]]
+  out2 <- roc_proc_text(roc, "
+    #' Title
+    #'
+    #' Link
+    #' text \\link[=fcn]{broken across lines} preserve
+    #' whitespace, even when
+    #' \\link[=fcn]{broken across several lines},
+    #' or with varying
+    #' \\link[=fcn]{amounts of interspersed whitespace}.
+    foo <- function() {}")[[1]]
+  expect_equivalent_rd(out1, out2)
+
+})
+


### PR DESCRIPTION
Fixes #754 White space is not preserved when link-reference text is split over lines

Unfortunately I did this before I saw #754 and the related PR #755 😔

In any case, I too extended @egnha's original solution for `[]()` style links to also handle `[][]` links.
The PRs are very similar, so let this be taken as evidence that one them should be merged!