### PR TITLE
Specify version of desc package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
 Imports: 
     brew,
     commonmark,
-    desc,
+    desc (>= 1.2.0),
     digest,
     methods,
     pkgload,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # roxygen2 6.1.0.9000
 
+* roxygen2 now specifically imports desc >= 1.2.0 (@crsh, #773, #777, #779)
+
 # roxygen2 6.1.0
 
 ## New features


### PR DESCRIPTION
Running `roxygenize()` with `desc` 1.1.0 throws the following error:

~~~
Error in .f(.x[[i]], ...) : attempt to apply non-function
~~~

This is caused by `read.description()` trying to access the non-existent function `get_field()` in the output of `desc()` (see [here](https://github.com/klutometis/roxygen/blob/master/R/utils.R)). `get_field()` was only added to the output with [version 1.2.0](https://github.com/r-lib/desc/blob/4f60833fdb6d1aae4cbf09b7eb293c5fa0770e5c/inst/NEWS.md#120) of `desc`.