### PR TITLE
Updates package_files to filter empty strings

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -3,8 +3,7 @@ package_files <- function(path) {
 
   all <- normalizePath(r_files(path))
 
-  collate <- scan(text = desc$Collate %||% "", what = "", sep = " ",
-    quiet = TRUE)
+  collate <- unlist(strsplit(gsub("'", "", desc$Collate), "\\n\\s*"))
 
   collate <- normalizePath(file.path(path, 'R', collate))
 


### PR DESCRIPTION
I found an error while trying to compile an roxygenized package in Windows when the Collate directive was added to the DESCRIPTION file. The problem is that the `package_files` function returns the path to the directory if there are leading whitespaces in the DESCRIPTION file.

I would recommend to change the `scan` function for regular expressions as they are safer and have full control under the string.

For example, if
```r
desc <- list(Collate = "'bar.R'\n    'foo.R'")
collate <- scan(text = desc$Collate, what = "", sep = " ")
collate
[1] "bar.R" ""      ""      ""     ""    "foo.R"
```

then;
```r
> file.path("path_to_package", "R", collate)
[1] "path_to_package/R/bar.R" "path_to_package/R"       "path_to_package/R"       "path_to_package/R"      
[5] "path_to_package/R"       "path_to_package/R/foo.R"
```

If we pass this paths to the `tokenize_file` function, it will throw an error. I propose:

```r
unlist(strsplit(gsub("'", "", desc$Collate), "\\n\\s*"))
[1] "bar.R"  "foo.R"
```