### PR TITLE
Add version requirement for `desc` package. Fixes #779.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
 Imports: 
     brew,
     commonmark,
-    desc,
+    desc (>= 1.2.0),
     digest,
     methods,
     pkgload,


### PR DESCRIPTION
The function `get_field()` used in `read.description()` in the file `R/utils.R` was introduced in version 1.2.0 of the `desc` package. A system with older versions of `desc` fails with the error message reported in issue #779 which is rather cryptic.