### PR TITLE
Display hex logo at 120px width

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # roxygen2 (development version)
 
+* Logo in package description is now scaled to a 120px width, cf. pkgdown websites (@peterdesmet, #834).
+
 # roxygen2 6.1.1
 
 * Now specifically imports recent version of desc package (>= 1.2.0) to

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 
 ## New features
 
-* The `NAMESPACE` roclet nows works in two passes - it first generates the
+* The `NAMESPACE` roclet now works in two passes - it first generates the
   `NAMESPACE` containing only import directives becaues this can be generated
   without evaluating the code in the package. This alleviates a problem
   where it was previously possible to get into a state that you could only

--- a/R/object-defaults.R
+++ b/R/object-defaults.R
@@ -32,7 +32,7 @@ object_defaults.package <- function(x) {
   description <- as.character(desc$Description)
   logo_path <- file.path(x$value$path, "man", "figures", "logo.png")
   if (file.exists(logo_path)) {
-    fig <- "\\if{html}{\\figure{logo.png}{options: align='right'}}"
+    fig <- "\\if{html}{\\figure{logo.png}{options: align='right' alt='logo' width='120'}}"
     description <- paste0(fig, "\n\n", description)
   }
 


### PR DESCRIPTION
Roxygen currently checks if there is a (hex) logo available and adds this to the `name-package.Rd` file as:

```R
\if{html}{\figure{logo.png}{options: align='right'}}
```

Positioning the logo on the right is also how `pkgdown` [instructs to add the logo](https://pkgdown.r-lib.org/articles/pkgdown.html#home-page) to the `README` (and thus pkgdown homepage), but there the logo also gets a width of 120px, so bigger logos still show nicely:

```
---
output: github_document
---

# pkgdown <img src="man/figures/logo.png" align="right" alt="" width="120" />
```

This PR:

- Also sets the width at 120px, so logos display nicely independent of their size when doing `?package`
- Sets an `alt='logo'`. This is in contrast with pkgdown where `alt` is empty (which I consider an oversight)

Note: I wasn't sure if the syntax for options was space or comma separated. I used space.
