### PR TITLE
Add column headers to \tabular{} generation in the Text Formatting vignette

### DIFF
--- a/vignettes/formatting.Rmd
+++ b/vignettes/formatting.Rmd
@@ -95,7 +95,7 @@ Tables are created with `\tabular{}`. It has two arguments:
 
 2. Table contents, with columns separated by `\tab` and rows by `\cr`.
 
-The following function turns an R data frame into into the correct format. It ignores column and row names, but should get you started.
+The following function turns an R data frame into the correct format, adding a row consisting of the (bolded) column names and prepending each row with `#' ` for pasting directly into the documentation.
 
 ```{r}
 tabular <- function(df, ...) {
@@ -106,10 +106,11 @@ tabular <- function(df, ...) {
 
   cols <- lapply(df, format, ...)
   contents <- do.call("paste",
-    c(cols, list(sep = " \\tab ", collapse = "\\cr\n  ")))
+    c(cols, list(sep = " \\tab ", collapse = "\\cr\n#'   ")))
 
-  paste("\\tabular{", paste(col_align, collapse = ""), "}{\n  ",
-    contents, "\n}\n", sep = "")
+  paste("#' \\tabular{", paste(col_align, collapse = ""), "}{\n#'   ",
+    paste0("\\strong{", names(df), "}", sep = "", collapse = " \\tab "), " \\cr\n#'   ",
+    contents, "\n#' }\n", sep = "")
 }
 
 cat(tabular(mtcars[1:5, 1:5]))


### PR DESCRIPTION
Modify `\tabular{}` table generation in the text formatting vignette to include a bolded column name row and `#' ` prefixes for roxygen documentation.

Having column headers seems like a common enough need (and the extra line is easily deleted if not wanted), and not having to prepend all the lines with `#' ` before pasting into the documentation seemed worthwhile.

Apologies if I'm doing this all wrong -- I've never attempted anything collaborative in GitHub before, so this tiny change is my first ever attempt at a Pull Request.